### PR TITLE
fix: include 'opening' device class for window/door sensor picker

### DIFF
--- a/frontend/src/components/rs-device-section.ts
+++ b/frontend/src/components/rs-device-section.ts
@@ -386,7 +386,7 @@ export class RsDeviceSection extends LitElement {
       ? allAreaEntities.filter(
           (e) =>
             e.entity_id.startsWith("binary_sensor.") &&
-            ["window", "door"].includes(
+            ["window", "door", "opening"].includes(
               this.hass.states[e.entity_id]?.attributes?.device_class as string,
             ),
         )
@@ -794,7 +794,7 @@ export class RsDeviceSection extends LitElement {
     }
     if (id.startsWith("binary_sensor.")) {
       const dc = this.hass.states[id]?.attributes?.device_class;
-      if (dc !== "window" && dc !== "door") return false;
+      if (dc !== "window" && dc !== "door" && dc !== "opening") return false;
     }
     // input_number: allow all (no device_class filtering)
     return true;


### PR DESCRIPTION
ZHA and many Zigbee integrations assign device_class 'opening' to contact sensors rather than 'window' or 'door'. This caused sensors with device_class 'opening' to be invisible in RoomMind's room configuration UI.

Adds 'opening' as a valid device class in both the area sensor list filter and the entity picker filter.

## What

Allows my window sensors to show up in RoomMind.

## Why

So we can detect more window and door sensors without having to customize them beyond the defaults.

## Checklist

- [ ] Backend tests pass (`pytest tests/ -v`)
- [ ] Frontend builds without errors (`cd frontend && npm run build`)
- [ ] New strings added to both `en.json` and `de.json` (if applicable)
- [ ] Tested on mobile layout (if UI change)
