### PR TITLE
feat: support device_tracker entities as presence sensors (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **Solar Gain Awareness** — Estimates solar irradiance from sun position and weather data. The model learns each room's solar response and reduces heating when sun is expected.
 - **Multi-Scheduler** — Multiple schedule entities per room with selector switching via `input_boolean` or `input_number`.
 - **Manual Override** — Boost, eco, or custom temperature with configurable duration and instant UI feedback.
-- **Presence-Based Scheduling** — Link schedules to `person.*` entities. A room's comfort schedule only applies when assigned persons are home — otherwise eco temperature is used.
+- **Presence-Based Scheduling** — Link schedules to `person.*`, `device_tracker.*`, `binary_sensor.*`, or `input_boolean.*` entities. A room's comfort schedule only applies when assigned persons are home — otherwise eco temperature is used.
 - **Vacation Mode** — Global setback temperature with end date for all rooms.
 - **Window/Door Pause** — Automatically pauses climate control when windows or doors are open, with configurable delays.
 - **Mold Risk Detection & Prevention** — Science-based mold risk assessment using surface humidity estimation (DIN 4108-2). Configurable notifications and automatic temperature raise to prevent mold growth.
@@ -130,7 +130,7 @@ Overrides have the highest priority and auto-clear when the timer expires.
 
 #### Presence
 
-Optionally assign `person.*` entities per room. The room's comfort schedule only applies when at least one assigned person is home — otherwise eco temperature is used. If no per-room persons are set, the global person list from settings applies.
+Optionally assign `person.*`, `device_tracker.*`, `binary_sensor.*`, or `input_boolean.*` entities per room. The room's comfort schedule only applies when at least one assigned person is home — otherwise eco temperature is used. If no per-room persons are set, the global person list from settings applies.
 
 ### Settings
 
@@ -145,7 +145,7 @@ Access settings via the gear tab in the RoomMind panel.
 | **Climate Control** | Master switch — when off, all devices are set to idle |
 | **Model Learning** | Enable/disable thermal model training globally. Expand to pause learning for individual rooms |
 | **Vacation Mode** | Set a global setback temperature + end date. All rooms use the vacation temperature until it expires |
-| **Presence** | Track `person.*` entities globally. Rooms only use comfort temperature when assigned persons are home |
+| **Presence** | Track `person.*`, `device_tracker.*`, `binary_sensor.*`, or `input_boolean.*` entities globally. Rooms only use comfort temperature when assigned persons are home |
 | **Valve Protection** | Periodically opens idle TRV valves to prevent seizing. Configure the idle threshold (1–90 days, default: 7) |
 
 #### Sensors & Weather
@@ -212,7 +212,7 @@ Manual Override  →  Vacation  →  Presence Away  →  Schedule Block  →  Co
 
 - **Manual override** — user-set temperature with timer (boost/eco/custom)
 - **Vacation** — global setback temperature until the configured end date
-- **Presence away** — eco temperature when all assigned persons are `not_home`
+- **Presence away** — eco temperature when all assigned persons are away (`not_home` for `person`/`device_tracker`, `off` for `binary_sensor`/`input_boolean`)
 - **Schedule block** — temperature from the active schedule block (if set), otherwise comfort temperature
 - **Comfort / Eco** — comfort when schedule is on, eco when schedule is off
 - **Mold prevention** — when active, adds +1/+2/+3 °C on top of the resolved target above
@@ -299,7 +299,7 @@ Hard-refresh your browser: **Cmd+Shift+R** (Mac) or **Ctrl+Shift+R** (Windows/Li
 
 - **Home Assistant** 2024.1.0 or newer
 - At least one HA **area** with a `climate.*` entity
-- Optional: external temperature sensor, humidity sensor, window/door sensors, weather entity, `schedule.*` helpers, `person.*` entities
+- Optional: external temperature sensor, humidity sensor, window/door sensors, weather entity, `schedule.*` helpers, `person.*` / `device_tracker.*` entities
 
 No external dependencies or cloud services required — everything runs locally.
 

--- a/custom_components/roommind/presence_utils.py
+++ b/custom_components/roommind/presence_utils.py
@@ -35,8 +35,8 @@ def is_presence_away(hass: HomeAssistant, room: dict, settings: dict) -> bool:
 def _is_entity_home(state) -> bool:
     """Check if a presence entity indicates someone is home.
 
-    person.* uses "home"/"not_home"; binary_sensor/input_boolean use "on"/"off".
+    person.*/device_tracker.* use "home"/"not_home"; binary_sensor/input_boolean use "on"/"off".
     """
-    if state.entity_id.startswith("person."):
+    if state.entity_id.startswith(("person.", "device_tracker.")):
         return state.state == "home"
     return state.state == "on"

--- a/frontend/src/components/rs-room-detail.ts
+++ b/frontend/src/components/rs-room-detail.ts
@@ -857,7 +857,7 @@ export class RsRoomDetail extends LitElement {
                 ${this._selectedPresencePersons.map((pid) => {
                   const name = this.hass.states[pid]?.attributes?.friendly_name ?? pid.split(".").slice(1).join(".");
                   const st = this.hass.states[pid]?.state;
-                  const isHome = pid.startsWith("person.") ? st === "home" : st === "on";
+                  const isHome = pid.startsWith("person.") || pid.startsWith("device_tracker.") ? st === "home" : st === "on";
                   return html`
                     <div class="presence-row ${isHome ? "home" : "away"}">
                       <span class="presence-dot"></span>

--- a/frontend/src/components/rs-settings.ts
+++ b/frontend/src/components/rs-settings.ts
@@ -632,7 +632,7 @@ export class RsSettings extends LitElement {
                     ` : nothing}
                     <ha-entity-picker
                       .hass=${this.hass}
-                      .includeDomains=${["person", "binary_sensor", "input_boolean"]}
+                      .includeDomains=${["person", "device_tracker", "binary_sensor", "input_boolean"]}
                       .entityFilter=${(entity: { entity_id: string }) => !this._presencePersons.includes(entity.entity_id)}
                       .label=${localize("presence.add_entity", l)}
                       @value-changed=${(e: CustomEvent) => {


### PR DESCRIPTION
## What

Add support for device_tracker entities for presence detection

## Why

Logical enhancement to existing presence detection

## Checklist

Regarding the checklist below: I would be awesome if the testing parts could be covered by GitHub actions, I usually prefer to keep my local environment "clean" if possible. An alternative approach (That would also enable real local testing) could be the integration of a devcontainer setup.

- [ ] Backend tests pass (`pytest tests/ -v`)
- [ ] Frontend builds without errors (`cd frontend && npm run build`)
- [ ] New strings added to both `en.json` and `de.json` (if applicable)
- [ ] Tested on mobile layout (if UI change)

Closes: #47 
