### PR TITLE
fix: offload blocking history_store I/O to executor (#51)

### DIFF
--- a/custom_components/roommind/diagnostics.py
+++ b/custom_components/roommind/diagnostics.py
@@ -86,7 +86,9 @@ async def async_get_config_entry_diagnostics(
     if coordinator and coordinator._history_store:
         for area_id in rooms_config:
             try:
-                rows = coordinator._history_store.read_detail(area_id, max_age=7200)
+                rows = await hass.async_add_executor_job(
+                    coordinator._history_store.read_detail, area_id, 7200
+                )
                 recent_history[area_id] = [
                     {
                         "ts": row.get("timestamp", ""),

--- a/custom_components/roommind/websocket_api.py
+++ b/custom_components/roommind/websocket_api.py
@@ -606,10 +606,14 @@ async def websocket_get_analytics(
     if history_store:
         if custom_start is not None:
             detail = _csv_to_points(
-                history_store.read_detail(area_id, start_ts=custom_start, end_ts=custom_end)
+                await hass.async_add_executor_job(
+                    history_store.read_detail, area_id, None, custom_start, custom_end
+                )
             )
             history = _csv_to_points(
-                history_store.read_history(area_id, start_ts=custom_start, end_ts=custom_end)
+                await hass.async_add_executor_job(
+                    history_store.read_history, area_id, None, custom_start, custom_end
+                )
             )
         else:
             max_age_map = {
@@ -622,8 +626,12 @@ async def websocket_get_analytics(
                 "90d": 7776000,
             }
             max_age = max_age_map.get(range_key, 43200)
-            detail = _csv_to_points(history_store.read_detail(area_id, max_age=max_age))
-            history = _csv_to_points(history_store.read_history(area_id, max_age=max_age))
+            detail = _csv_to_points(
+                await hass.async_add_executor_job(history_store.read_detail, area_id, max_age)
+            )
+            history = _csv_to_points(
+                await hass.async_add_executor_job(history_store.read_history, area_id, max_age)
+            )
 
     # Model info (only if estimator exists — avoid auto-creating for unknown rooms)
     model_info: dict = {}

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1101,7 +1101,7 @@ async def test_analytics_with_range_key(ws_hass, store, connection):
     assert len(result["detail"]) == 1
     assert result["detail"][0]["ts"] == 1000.0
     # read_detail was called with max_age=86400
-    coordinator._history_store.read_detail.assert_called_once_with("room_a", max_age=86400)
+    coordinator._history_store.read_detail.assert_called_once_with("room_a", 86400)
 
 
 @pytest.mark.asyncio
@@ -1127,7 +1127,7 @@ async def test_analytics_with_custom_timestamps(ws_hass, store, connection):
     result = connection.send_result.call_args[0][1]
     assert len(result["detail"]) == 1
     coordinator._history_store.read_detail.assert_called_once_with(
-        "room_a", start_ts=1000.0, end_ts=2000.0,
+        "room_a", None, 1000.0, 2000.0,
     )
 
 


### PR DESCRIPTION
## What

Wrap all HistoryStore.read_detail() and read_history() calls in websocket_api.py and diagnostics.py with hass.async_add_executor_job() to move blocking file I/O off the event loop.

## Why

Synchronous open() calls in history_store.py block the Home Assistant event loop when invoked from async websocket/diagnostics handlers, freezing all other HA tasks until the CSV read completes. HA detects this and logs a Detected blocking call to open warning.

Closes: #51 

## Checklist

- [ ] Backend tests pass (`pytest tests/ -v`)
- [ ] Frontend builds without errors (`cd frontend && npm run build`)
- [ ] New strings added to both `en.json` and `de.json` (if applicable)
- [ ] Tested on mobile layout (if UI change)
