### PR TITLE
fix: use _ALPHA_MIN floor in get_model instead of hardcoded 0.1

### DIFF
--- a/custom_components/roommind/thermal_model.py
+++ b/custom_components/roommind/thermal_model.py
@@ -540,7 +540,7 @@ class ThermalEKF:
         """
         return RCModel(
             C=1.0,
-            U=max(self._x[1], 0.1),
+            U=max(self._x[1], self._ALPHA_MIN),
             Q_heat=max(self._x[2], 0.0),
             Q_cool=max(self._x[3], 0.0),
             Q_solar=max(self._x[4], 0.0),

--- a/tests/test_mpc_controller.py
+++ b/tests/test_mpc_controller.py
@@ -169,6 +169,9 @@ async def test_mpc_path_when_confident():
     # Mock prediction_std to be low (confident) + enough training data
     model_mgr.get_prediction_std = MagicMock(return_value=0.1)
     model_mgr.get_mode_counts = MagicMock(return_value=(100, 30, 0))
+    # Mock a realistic trained model (2 EKF updates give alpha=_ALPHA_MIN which is
+    # too low for the optimizer to distinguish heating from idle via T_eq clamping)
+    model_mgr.get_model = MagicMock(return_value=RCModel(C=1.0, U=0.15, Q_heat=3.0, Q_cool=4.0))
     ctrl = MPCController(
         hass, room, model_manager=model_mgr,
         outdoor_temp=5.0, settings={}, has_external_sensor=True,
@@ -190,6 +193,9 @@ async def test_confidence_transition_threshold():
 
     # Enough training data for MPC
     model_mgr.get_mode_counts = MagicMock(return_value=(100, 30, 0))
+    # Mock a realistic trained model (2 EKF updates give alpha=_ALPHA_MIN which is
+    # too low for the optimizer to distinguish heating from idle via T_eq clamping)
+    model_mgr.get_model = MagicMock(return_value=RCModel(C=1.0, U=0.15, Q_heat=3.0, Q_cool=4.0))
 
     # Just above threshold — bang-bang
     model_mgr.get_prediction_std = MagicMock(return_value=0.5)
@@ -463,6 +469,9 @@ async def test_proportional_power_far_from_target():
     model_mgr.update("living_room", 16.0, 5.0, "heating", 5.0)
     model_mgr.get_prediction_std = MagicMock(return_value=0.1)
     model_mgr.get_mode_counts = MagicMock(return_value=(100, 30, 0))
+    # Mock a realistic trained model (2 EKF updates give alpha=_ALPHA_MIN which is
+    # too low for the optimizer to distinguish heating from idle via T_eq clamping)
+    model_mgr.get_model = MagicMock(return_value=RCModel(C=1.0, U=0.15, Q_heat=3.0, Q_cool=4.0))
     ctrl = MPCController(
         hass, room, model_manager=model_mgr,
         outdoor_temp=5.0, settings={}, has_external_sensor=True,


### PR DESCRIPTION
## What

use _ALPHA_MIN floor in get_model instead of hardcoded 0.1

## Why
The hardcoded 0.1 floor in ThermalEKF.get_model() was inflating the exported heat loss coefficient (U) above the true learned value, causing the optimizer to overestimate heat loss for well-insulated rooms

Update three tests that relied on the old floor by mocking get_model with a realistic trained model, consistent with how other MPC path tests are structured.

## Checklist

- [ ] Backend tests pass (`pytest tests/ -v`)
- [ ] Frontend builds without errors (`cd frontend && npm run build`)
- [ ] New strings added to both `en.json` and `de.json` (if applicable)
- [ ] Tested on mobile layout (if UI change)
