### PR TITLE
Enforce minimum runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           pip install pytest pytest-asyncio pytest-cov homeassistant voluptuous
 
       - name: Run tests with coverage
-        run: pytest tests/ -v --cov=custom_components/roommind --cov-report=term
+        run: pytest tests/ -v --cov=custom_components/roommind --cov-report=term --cov-fail-under=95
         env:
           COVERAGE_RCFILE: .coveragerc
 

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py.cover
 .hypothesis/

--- a/custom_components/roommind/control/mpc_controller.py
+++ b/custom_components/roommind/control/mpc_controller.py
@@ -25,6 +25,7 @@ from ..const import (
 from .mpc_optimizer import MPCOptimizer, MPCPlan
 from ..utils.temp_utils import celsius_to_ha_temp
 from .thermal_model import RoomModelManager
+from .residual_heat import get_min_run_blocks
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -241,6 +242,7 @@ class MPCController:
         cloud_series: list[float | None] | None = None,
         q_residual: float = 0.0,
         heating_system_type: str = "",
+        mode_on_since: float | None = None,
     ) -> None:
         self.hass = hass
         self.room_config = room_config
@@ -261,6 +263,7 @@ class MPCController:
         self._cloud_series = cloud_series or []
         self.q_residual = q_residual
         self._heating_system_type = heating_system_type
+        self._mode_on_since = mode_on_since
 
         s = settings or {}
         self.outdoor_cooling_min = s.get("outdoor_cooling_min", DEFAULT_OUTDOOR_COOLING_MIN)
@@ -326,6 +329,17 @@ class MPCController:
         if can_cool and n_cooling < MIN_ACTIVE_UPDATES:
             return False
         return True
+
+    def _within_min_run(self, mode: str) -> bool:
+        """Return True if the given mode is currently active and within its minimum run window.
+
+        Used to prevent premature shutdown of slow heating systems (e.g. underfloor)
+        that need a guaranteed minimum run time before being allowed to idle.
+        """
+        if self.previous_mode != mode or self._mode_on_since is None:
+            return False
+        min_run_seconds = get_min_run_blocks(self._heating_system_type, PLAN_DT_MINUTES) * PLAN_DT_MINUTES * 60
+        return (time.time() - self._mode_on_since) < min_run_seconds
 
     def _evaluate_mpc(
         self,
@@ -409,15 +423,18 @@ class MPCController:
         power_fraction = plan.get_current_power_fraction()
 
         # Safety guard: don't heat above the maximum upcoming target,
-        # don't cool below the minimum upcoming target.
+        # don't cool below the minimum upcoming target, while preserving
+        # pre-heating/pre-cooling when a schedule change justifies it.
         near_heat = heat_target_series[:6]
         near_cool = cool_target_series[:6]
         if near_heat and action == MODE_HEATING and current_temp >= max(near_heat):
-            action = MODE_IDLE
-            power_fraction = 0.0
+            if not self._within_min_run(MODE_HEATING):
+                action = MODE_IDLE
+                power_fraction = 0.0
         elif near_cool and action == MODE_COOLING and current_temp <= min(near_cool):
-            action = MODE_IDLE
-            power_fraction = 0.0
+            if not self._within_min_run(MODE_COOLING):
+                action = MODE_IDLE
+                power_fraction = 0.0
 
         return action, power_fraction
 
@@ -436,12 +453,12 @@ class MPCController:
 
         # Mode stickiness
         if self.previous_mode == MODE_HEATING and can_heat and heat_target is not None:
-            if current_temp < heat_target:
+            if current_temp < heat_target or self._within_min_run(MODE_HEATING):
                 return MODE_HEATING
             return MODE_IDLE
 
         if self.previous_mode == MODE_COOLING and can_cool and cool_target is not None:
-            if current_temp > cool_target:
+            if current_temp > cool_target or self._within_min_run(MODE_COOLING):
                 return MODE_COOLING
             return MODE_IDLE
 

--- a/custom_components/roommind/coordinator.py
+++ b/custom_components/roommind/coordinator.py
@@ -77,6 +77,8 @@ class RoomMindCoordinator(DataUpdateCoordinator):
         self._residual_tracker = ResidualHeatTracker()
         # Track which rooms already have sensor entities registered
         self._entity_areas: set[str] = set()
+        # Min-run enforcement: timestamp when current non-idle mode started
+        self._mode_on_since: dict[str, float] = {}
 
     async def _async_update_data(self) -> dict:
         """Fetch and compute state for all rooms.
@@ -303,6 +305,7 @@ class RoomMindCoordinator(DataUpdateCoordinator):
             outdoor_forecast=outdoor_forecast,
             settings=settings,
             previous_mode=self._previous_modes.get(area_id, MODE_IDLE),
+            mode_on_since=self._mode_on_since.get(area_id),
             has_external_sensor=has_external_sensor,
             target_resolver=target_resolver,
             q_solar=self._current_q_solar,
@@ -467,6 +470,12 @@ class RoomMindCoordinator(DataUpdateCoordinator):
             self._ekf_accumulated_mode.pop(area_id, None)
             self._ekf_accumulated_pf.pop(area_id, None)
 
+        # Update mode-start tracking for min-run enforcement in the next cycle
+        _prev_mode = self._previous_modes.get(area_id, MODE_IDLE)
+        if mode != MODE_IDLE and _prev_mode != mode:
+            self._mode_on_since[area_id] = time.time()
+        elif mode == MODE_IDLE:
+            self._mode_on_since.pop(area_id, None)
         self._previous_modes[area_id] = mode
 
         # Compute MPC status for live data
@@ -809,6 +818,7 @@ class RoomMindCoordinator(DataUpdateCoordinator):
         self._pending_predictions.pop(area_id, None)
         self._residual_tracker.remove_room(area_id)
         self._entity_areas.discard(area_id)
+        self._mode_on_since.pop(area_id, None)
         self._model_manager.remove_room(area_id)
         if self._history_store:
             await self.hass.async_add_executor_job(self._history_store.remove_room, area_id)

--- a/tests/integration/test_multi_cycle.py
+++ b/tests/integration/test_multi_cycle.py
@@ -34,6 +34,8 @@ class TestMultiCycle:
         mode1 = data1["rooms"]["living_room"]["mode"]
 
         # Cycle 2: temp at target -> should idle
+        # Backdate mode_on_since to bypass min-run enforcement window
+        coordinator._mode_on_since["living_room"] = coordinator._mode_on_since.get("living_room", 0) - 4000
         coordinator.hass.states.get = MagicMock(side_effect=make_hass_states(temp="21.5"))
         data2 = await coordinator._async_update_data()
         mode2 = data2["rooms"]["living_room"]["mode"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3202,6 +3202,9 @@ class TestResidualHeatTracking:
         assert aid in coordinator._residual_tracker._on_since
         assert coordinator._previous_modes.get(aid) == "heating"
 
+        # Backdate mode_on_since so the min-run window has already elapsed
+        coordinator._mode_on_since[aid] = time.time() - 10000
+
         # Cycle 2: idle (schedule off -> eco 17, temp 18 above eco -> idle)
         hass.states.get = make_mock_states_get(
             temp="18.0", schedule_state="off",
@@ -3232,6 +3235,9 @@ class TestResidualHeatTracking:
         coordinator = _create_coordinator(hass, mock_config_entry)
         await coordinator._async_update_data()
         assert coordinator._previous_modes.get(aid) == "heating"
+
+        # Backdate mode_on_since so the min-run window has already elapsed
+        coordinator._mode_on_since[aid] = time.time() - 10000
 
         # Cycle 2: idle
         hass.states.get = make_mock_states_get(

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -314,3 +314,26 @@ def test_safe_ts_non_numeric():
 def test_safe_ts_none_value():
     """None timestamp returns 0.0."""
     assert HistoryStore._safe_ts({"timestamp": None}) == 0.0
+
+
+def test_read_detail_with_end_ts_filter(history_dir):
+    """read_detail with end_ts filters out records after the cutoff."""
+    import time as _time
+    store = HistoryStore(history_dir)
+    now = _time.time()
+    store.record("living_room", {"room_temp": 21.0, "outdoor_temp": 5.0, "target_temp": 21.0, "mode": "idle", "predicted_temp": 21.0})
+    rows = store.read_detail("living_room", end_ts=now - 10)
+    assert len(rows) == 0
+
+
+def test_rotate_trims_old_history(history_dir):
+    """rotate() should trim history records older than HISTORY_MAX_AGE."""
+    import time as _time
+    from custom_components.roommind.utils.history_store import HISTORY_MAX_AGE
+    store = HistoryStore(history_dir)
+    # Write one very old record directly into history
+    old_ts = _time.time() - HISTORY_MAX_AGE - 1000
+    store._append_history("room1", [{"timestamp": str(old_ts), "room_temp": "20.0"}])
+    assert len(store.read_history("room1")) == 1
+    store.rotate("room1")
+    assert len(store.read_history("room1")) == 0

--- a/tests/test_mpc_controller.py
+++ b/tests/test_mpc_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
@@ -1663,6 +1664,58 @@ async def test_bangbang_none_inputs():
     assert ctrl._evaluate_bangbang(20.0, TargetTemps(heat=None, cool=None)) == MODE_IDLE
 
 
+@pytest.mark.asyncio
+async def test_bangbang_heating_min_run_holds_at_target():
+    """Underfloor heating must keep running when at target but within min-run window."""
+    hass = build_hass()
+    room = make_room()
+    mgr = RoomModelManager()
+    ctrl = MPCController(
+        hass, room, model_manager=mgr,
+        outdoor_temp=5.0, settings={}, has_external_sensor=True,
+        previous_mode=MODE_HEATING,
+        heating_system_type="underfloor",
+        mode_on_since=time.time() - 60,  # 1 min in, window is 30 min
+    )
+    # current_temp equals target — without min-run this would go idle
+    mode = ctrl._evaluate_bangbang(21.0, TargetTemps(heat=21.0, cool=24.0))
+    assert mode == MODE_HEATING
+
+
+@pytest.mark.asyncio
+async def test_bangbang_heating_idles_after_min_run():
+    """Underfloor heating goes idle at target once the min-run window has elapsed."""
+    hass = build_hass()
+    room = make_room()
+    mgr = RoomModelManager()
+    ctrl = MPCController(
+        hass, room, model_manager=mgr,
+        outdoor_temp=5.0, settings={}, has_external_sensor=True,
+        previous_mode=MODE_HEATING,
+        heating_system_type="underfloor",
+        mode_on_since=time.time() - 2000,  # 33 min ago, past 30-min window
+    )
+    mode = ctrl._evaluate_bangbang(21.5, TargetTemps(heat=21.0, cool=24.0))
+    assert mode == MODE_IDLE
+
+
+@pytest.mark.asyncio
+async def test_bangbang_cooling_min_run_holds_at_target():
+    """Cooling must keep running when at target but within min-run window."""
+    hass = build_hass()
+    room = make_room(acs=["climate.ac1"], climate_mode="cool_only")
+    mgr = RoomModelManager()
+    ctrl = MPCController(
+        hass, room, model_manager=mgr,
+        outdoor_temp=30.0, settings={}, has_external_sensor=True,
+        previous_mode=MODE_COOLING,
+        heating_system_type="underfloor",
+        mode_on_since=time.time() - 60,
+    )
+    mode = ctrl._evaluate_bangbang(23.0, TargetTemps(heat=21.0, cool=23.0))
+    assert mode == MODE_COOLING
+
+
 # ---------------------------------------------------------------------------
 # _evaluate_mpc edge cases
 # ---------------------------------------------------------------------------
@@ -2131,6 +2184,84 @@ def test_evaluate_mpc_safety_guard_cooling_below_target(monkeypatch):
     )
     # current_temp=22 <= target=23 → safety guard should override to idle
     mode, pf = ctrl._evaluate_mpc(22.0, TargetTemps(heat=21.0, cool=23.0))
+    assert mode == MODE_IDLE
+    assert pf == 0.0
+
+
+def test_evaluate_mpc_safety_guard_respects_min_run_heating(monkeypatch):
+    """Safety guard must NOT override heating when within minimum run window."""
+    hass = build_hass()
+    room = make_room()
+    mgr = RoomModelManager()
+    ctrl = MPCController(
+        hass, room, model_manager=mgr,
+        outdoor_temp=5.0, settings={}, has_external_sensor=True,
+        previous_mode=MODE_HEATING,
+        heating_system_type="underfloor",
+        mode_on_since=time.time() - 60,  # started 1 min ago (within 30-min window)
+    )
+    fake_plan = MPCPlan(
+        actions=[MODE_HEATING] * 6,
+        temperatures=[22.0] * 7,
+        power_fractions=[0.8] * 6,
+    )
+    monkeypatch.setattr(
+        "custom_components.roommind.control.mpc_controller.MPCOptimizer.optimize",
+        lambda *a, **kw: fake_plan,
+    )
+    # current_temp=22 >= target=21 but we're in min-run window → must keep heating
+    mode, pf = ctrl._evaluate_mpc(22.0, TargetTemps(heat=21.0, cool=24.0))
+    assert mode == MODE_HEATING
+
+
+def test_evaluate_mpc_safety_guard_fires_after_min_run_heating(monkeypatch):
+    """Safety guard must override heating when minimum run window has elapsed."""
+    hass = build_hass()
+    room = make_room()
+    mgr = RoomModelManager()
+    ctrl = MPCController(
+        hass, room, model_manager=mgr,
+        outdoor_temp=5.0, settings={}, has_external_sensor=True,
+        previous_mode=MODE_HEATING,
+        heating_system_type="underfloor",
+        mode_on_since=time.time() - 2000,  # started 33 min ago (past 30-min window)
+    )
+    fake_plan = MPCPlan(
+        actions=[MODE_HEATING] * 6,
+        temperatures=[22.0] * 7,
+        power_fractions=[0.8] * 6,
+    )
+    monkeypatch.setattr(
+        "custom_components.roommind.control.mpc_controller.MPCOptimizer.optimize",
+        lambda *a, **kw: fake_plan,
+    )
+    mode, pf = ctrl._evaluate_mpc(22.0, TargetTemps(heat=21.0, cool=24.0))
+    assert mode == MODE_IDLE
+    assert pf == 0.0
+
+
+def test_evaluate_mpc_safety_guard_fires_after_default_min_run_heating(monkeypatch):
+    """Safety guard must override heating when default minimum run window has elapsed."""
+    hass = build_hass()
+    room = make_room()
+    mgr = RoomModelManager()
+    ctrl = MPCController(
+        hass, room, model_manager=mgr,
+        outdoor_temp=5.0, settings={}, has_external_sensor=True,
+        previous_mode=MODE_HEATING,
+        heating_system_type="",
+        mode_on_since=time.time() - 660,  # started 11 min ago (past 10-min default window)
+    )
+    fake_plan = MPCPlan(
+        actions=[MODE_HEATING] * 6,
+        temperatures=[22.0] * 7,
+        power_fractions=[0.8] * 6,
+    )
+    monkeypatch.setattr(
+        "custom_components.roommind.control.mpc_controller.MPCOptimizer.optimize",
+        lambda *a, **kw: fake_plan,
+    )
+    mode, pf = ctrl._evaluate_mpc(22.0, TargetTemps(heat=21.0, cool=24.0))
     assert mode == MODE_IDLE
     assert pf == 0.0
 

--- a/tests/test_notification_utils.py
+++ b/tests/test_notification_utils.py
@@ -219,3 +219,42 @@ def test_dismiss_notification_prevention_suffix():
         dismiss_mold_notification(hass, "bedroom", "prevention")
 
     mock_dismiss.assert_called_once_with(hass, "roommind_mold_bedroom_prevention")
+
+
+@pytest.mark.asyncio
+async def test_send_notification_skips_target_with_empty_entity_id():
+    """Target with empty entity_id should be skipped (no notify call)."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+
+    targets = [{"entity_id": "", "person_entity": "", "notify_when": "always"}]
+
+    with patch(
+        "custom_components.roommind.utils.notification_utils.async_create"
+    ) as mock_create:
+        await async_send_mold_notification(
+            hass, "living_room", "Wohnzimmer", targets,
+            message="Test", title="Test",
+        )
+
+    hass.services.async_call.assert_not_called()
+    mock_create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_notification_service_exception_triggers_fallback():
+    """If notify service raises, warning is logged and fallback is used."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock(side_effect=Exception("service unavailable"))
+
+    targets = [{"entity_id": "notify.test", "person_entity": "", "notify_when": "always"}]
+
+    with patch(
+        "custom_components.roommind.utils.notification_utils.async_create"
+    ) as mock_create:
+        await async_send_mold_notification(
+            hass, "living_room", "Wohnzimmer", targets,
+            message="Test", title="Test",
+        )
+
+    mock_create.assert_called_once()

--- a/tests/test_presence_utils.py
+++ b/tests/test_presence_utils.py
@@ -1,0 +1,41 @@
+"""Tests for presence_utils.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.roommind.utils.presence_utils import is_presence_away
+
+
+def _make_state(entity_id: str, state: str) -> MagicMock:
+    s = MagicMock()
+    s.entity_id = entity_id
+    s.state = state
+    return s
+
+
+def test_presence_enabled_but_no_persons_returns_false():
+    """When presence_enabled but presence_persons is empty, return False."""
+    hass = MagicMock()
+    settings = {"presence_enabled": True, "presence_persons": []}
+    assert is_presence_away(hass, {}, settings) is False
+
+
+def test_binary_sensor_off_counts_as_away():
+    """binary_sensor 'off' means not home → if all away, returns True."""
+    hass = MagicMock()
+    hass.states.get = MagicMock(
+        return_value=_make_state("binary_sensor.motion", "off")
+    )
+    settings = {"presence_enabled": True, "presence_persons": ["binary_sensor.motion"]}
+    assert is_presence_away(hass, {}, settings) is True
+
+
+def test_binary_sensor_on_counts_as_home():
+    """binary_sensor 'on' means home → returns False."""
+    hass = MagicMock()
+    hass.states.get = MagicMock(
+        return_value=_make_state("binary_sensor.motion", "on")
+    )
+    settings = {"presence_enabled": True, "presence_persons": ["binary_sensor.motion"]}
+    assert is_presence_away(hass, {}, settings) is False

--- a/tests/test_residual_heat.py
+++ b/tests/test_residual_heat.py
@@ -151,3 +151,14 @@ def test_min_run_blocks_never_below_two():
 def test_min_run_blocks_zero_dt():
     """Zero dt returns fallback."""
     assert get_min_run_blocks("underfloor", 0.0) == 2
+
+
+def test_tau_zero_returns_zero():
+    """A profile with tau=0 should return 0.0 to avoid division by zero."""
+    from unittest.mock import patch
+    from custom_components.roommind.control import residual_heat as rh
+
+    fake_profiles = {"zero_tau": {"tau_minutes": 0, "initial_fraction": 0.5}}
+    with patch.object(rh, "HEATING_SYSTEM_PROFILES", fake_profiles):
+        result = rh.compute_residual_heat(5.0, "zero_tau", 1.0, 60.0)
+    assert result == 0.0

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -363,3 +363,29 @@ async def test_save_eco_temp_reverse_syncs_eco_heat(store):
     updated = await store.async_save_room("wohnzimmer", {"eco_temp": 16.0})
 
     assert updated["eco_heat"] == 16.0
+
+
+@pytest.mark.asyncio
+async def test_save_room_syncs_comfort_heat_to_comfort_temp_on_update(store):
+    """Updating an existing room with comfort_heat should sync comfort_temp."""
+    await store.async_load()
+    await store.async_save_room("wohnzimmer", {})
+    updated = await store.async_save_room("wohnzimmer", {"comfort_heat": 23.0})
+    assert updated["comfort_temp"] == 23.0
+
+
+@pytest.mark.asyncio
+async def test_save_room_syncs_eco_heat_to_eco_temp_on_update(store):
+    """Updating an existing room with eco_heat should sync eco_temp."""
+    await store.async_load()
+    await store.async_save_room("wohnzimmer", {})
+    updated = await store.async_save_room("wohnzimmer", {"eco_heat": 15.0})
+    assert updated["eco_temp"] == 15.0
+
+
+@pytest.mark.asyncio
+async def test_update_room_missing_raises_key_error(store):
+    """async_update_room on a non-existent room should raise KeyError."""
+    await store.async_load()
+    with pytest.raises(KeyError):
+        await store.async_update_room("nonexistent", {"comfort_temp": 21.0})

--- a/tests/test_weather_manager.py
+++ b/tests/test_weather_manager.py
@@ -1,0 +1,89 @@
+"""Tests for WeatherManager."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.const import UnitOfTemperature
+
+from custom_components.roommind.managers.weather_manager import WeatherManager
+
+
+def _make_hass(fahrenheit: bool = False) -> MagicMock:
+    hass = MagicMock()
+    hass.config.units.temperature_unit = (
+        UnitOfTemperature.FAHRENHEIT if fahrenheit else UnitOfTemperature.CELSIUS
+    )
+    hass.states.get = MagicMock(return_value=None)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_no_weather_entity_returns_empty():
+    """When no weather_entity is configured, forecast is empty."""
+    mgr = WeatherManager(_make_hass())
+    result = await mgr.async_read_forecast({})
+    assert result == []
+    assert mgr.forecast == []
+
+
+@pytest.mark.asyncio
+async def test_service_response_parsed_and_stored():
+    """Successful get_forecasts service call returns converted forecast."""
+    hass = _make_hass()
+    hass.services.async_call = AsyncMock(return_value={
+        "weather.home": {"forecast": [{"temperature": 10.0}, {"temperature": 12.0}]}
+    })
+
+    mgr = WeatherManager(hass)
+    result = await mgr.async_read_forecast({"weather_entity": "weather.home"})
+
+    assert len(result) == 2
+    assert result[0]["temperature"] == 10.0
+    assert mgr.forecast == result
+
+
+@pytest.mark.asyncio
+async def test_service_response_converts_fahrenheit():
+    """Forecast temperatures are converted from °F to °C when HA uses Fahrenheit."""
+    hass = _make_hass(fahrenheit=True)
+    hass.services.async_call = AsyncMock(return_value={
+        "weather.home": {"forecast": [{"temperature": 50.0}]}  # 50°F = 10°C
+    })
+
+    mgr = WeatherManager(hass)
+    result = await mgr.async_read_forecast({"weather_entity": "weather.home"})
+
+    assert abs(result[0]["temperature"] - 10.0) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_service_failure_falls_back_to_state_attributes():
+    """If get_forecasts service fails, falls back to state attributes."""
+    hass = _make_hass()
+    hass.services.async_call = AsyncMock(side_effect=Exception("service unavailable"))
+
+    state = MagicMock()
+    state.attributes = {"forecast": [{"temperature": 8.0}]}
+    hass.states.get = MagicMock(return_value=state)
+
+    mgr = WeatherManager(hass)
+    result = await mgr.async_read_forecast({"weather_entity": "weather.home"})
+
+    assert len(result) == 1
+    assert result[0]["temperature"] == 8.0
+
+
+@pytest.mark.asyncio
+async def test_service_failure_no_state_returns_empty():
+    """If service fails and state is unavailable, returns empty list."""
+    hass = _make_hass()
+    hass.services.async_call = AsyncMock(side_effect=Exception("unavailable"))
+    hass.states.get = MagicMock(return_value=None)
+
+    mgr = WeatherManager(hass)
+    result = await mgr.async_read_forecast({"weather_entity": "weather.home"})
+
+    assert result == []

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1362,3 +1362,127 @@ async def test_save_room_heating_system_type_defaults_empty(ws_hass, store, conn
     assert room.get("heating_system_type", "") == ""
 
 
+
+
+# ---------------------------------------------------------------------------
+# Override set: cool_only climate mode paths
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_override_set_boost_cool_only_uses_comfort_cool(ws_hass, store, connection):
+    """Boost override in cool_only room uses comfort_cool temperature."""
+    await store.async_load()
+    await store.async_save_room("room1", {"climate_mode": "cool_only", "comfort_cool": 26.0})
+    connection.send_result.reset_mock()
+
+    msg = {
+        "id": 1, "type": "roommind/override/set",
+        "area_id": "room1", "override_type": "boost", "duration": 1.0,
+    }
+    await _override_set(ws_hass, connection, msg)
+
+    room = store.get_room("room1")
+    assert room["override_temp"] == 26.0
+
+
+@pytest.mark.asyncio
+async def test_override_set_eco_cool_only_uses_eco_cool(ws_hass, store, connection):
+    """Eco override in cool_only room uses eco_cool temperature."""
+    await store.async_load()
+    await store.async_save_room("room1", {"climate_mode": "cool_only", "eco_cool": 29.0})
+    connection.send_result.reset_mock()
+
+    msg = {
+        "id": 1, "type": "roommind/override/set",
+        "area_id": "room1", "override_type": "eco", "duration": 1.0,
+    }
+    await _override_set(ws_hass, connection, msg)
+
+    room = store.get_room("room1")
+    assert room["override_temp"] == 29.0
+
+
+@pytest.mark.asyncio
+async def test_override_set_triggers_coordinator_refresh(ws_hass, store, connection):
+    """override/set notifies coordinator via async_request_refresh."""
+    await store.async_load()
+    await store.async_save_room("kitchen", {})
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.async_request_refresh = AsyncMock()
+    ws_hass.data[DOMAIN]["coordinator"] = mock_coordinator
+
+    msg = {
+        "id": 1, "type": "roommind/override/set",
+        "area_id": "kitchen", "override_type": "boost", "duration": 1.0,
+    }
+    await _override_set(ws_hass, connection, msg)
+
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_override_clear_nonexistent_room_errors(ws_hass, store, connection):
+    """Clearing override on non-existent room sends an error."""
+    await store.async_load()
+
+    msg = {"id": 1, "type": "roommind/override/clear", "area_id": "does_not_exist"}
+    await _override_clear(ws_hass, connection, msg)
+
+    connection.send_error.assert_called_once()
+    assert connection.send_error.call_args[0][1] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_override_clear_triggers_coordinator_refresh(ws_hass, store, connection):
+    """override/clear notifies coordinator via async_request_refresh."""
+    await store.async_load()
+    await store.async_save_room("hall", {})
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.async_request_refresh = AsyncMock()
+    ws_hass.data[DOMAIN]["coordinator"] = mock_coordinator
+
+    msg = {"id": 1, "type": "roommind/override/clear", "area_id": "hall"}
+    await _override_clear(ws_hass, connection, msg)
+
+    mock_coordinator.async_request_refresh.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Boost learning
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_boost_learning_no_coordinator_errors(ws_hass, store, connection):
+    """boost_learning without coordinator sends an error."""
+    from custom_components.roommind.websocket_api import websocket_boost_learning
+    _boost_learning = websocket_boost_learning.__wrapped__
+
+    await store.async_load()
+    # No coordinator in hass.data
+    msg = {"id": 1, "type": "roommind/model/boost_learning", "area_id": "living_room"}
+    await _boost_learning(ws_hass, connection, msg)
+
+    connection.send_error.assert_called_once()
+    assert connection.send_error.call_args[0][1] == "no_coordinator"
+
+
+@pytest.mark.asyncio
+async def test_boost_learning_success(ws_hass, store, connection):
+    """boost_learning with coordinator boosts EKF and persists cooldown."""
+    from custom_components.roommind.websocket_api import websocket_boost_learning
+    _boost_learning = websocket_boost_learning.__wrapped__
+
+    await store.async_load()
+
+    mock_coordinator = MagicMock()
+    mock_coordinator._model_manager = MagicMock()
+    mock_coordinator._model_manager.boost_learning = MagicMock(return_value=42)
+    ws_hass.data[DOMAIN]["coordinator"] = mock_coordinator
+
+    msg = {"id": 1, "type": "roommind/model/boost_learning", "area_id": "living_room"}
+    await _boost_learning(ws_hass, connection, msg)
+
+    mock_coordinator._model_manager.boost_learning.assert_called_once_with("living_room")
+    connection.send_result.assert_called_once_with(1, {"success": True, "n_observations": 42})

--- a/tests/test_window_manager.py
+++ b/tests/test_window_manager.py
@@ -1,0 +1,19 @@
+"""Tests for WindowManager."""
+
+from __future__ import annotations
+
+from custom_components.roommind.managers.window_manager import WindowManager
+
+
+def test_is_paused_default_false():
+    """is_paused returns False for an unknown room."""
+    mgr = WindowManager()
+    assert mgr.is_paused("living_room") is False
+
+
+def test_is_paused_after_window_opens():
+    """is_paused returns True after window has been open past the delay."""
+    mgr = WindowManager()
+    # open_delay=0 → immediate pause
+    mgr.update("living_room", raw_open=True, open_delay=0, close_delay=0)
+    assert mgr.is_paused("living_room") is True


### PR DESCRIPTION
## What

Adds a minimum run time enforcement for heating and cooling modes. When a room switches to heating or cooling, RoomMind now tracks when that mode started and prevents the MPC controller from switching back to idle until a system-type-specific minimum duration has elapsed.

The minimum run time is derived from get_min_run_blocks (already used for residual heat) and varies by heating system type (e.g. longer for underfloor heating than radiators).

## Why

The MPC optimizer sometimes produces a control signal that immediately satisfies the temperature target (e.g. temperature reaches the near-horizon max), causing the system to idle after just one 30-second cycle. This could be harmful to valves and inefficient for systems with high thermal inertia.

## Checklist

- [ ] Backend tests pass (`pytest tests/ -v`)
- [ ] Frontend builds without errors (`cd frontend && npm run build`)
- [ ] New strings added to both `en.json` and `de.json` (if applicable)
- [ ] Tested on mobile layout (if UI change)
