### PR TITLE
fix: stats bar overflows on mobile when multiple indicators shown

### DIFF
--- a/frontend/src/roommind-panel.ts
+++ b/frontend/src/roommind-panel.ts
@@ -217,12 +217,14 @@ export class RoomMindPanel extends LitElement {
       height: 28px;
       background: var(--divider-color, #444);
       margin: 0 4px;
+      flex-shrink: 0;
     }
 
     .stats-bar {
       display: flex;
       align-items: center;
-      gap: 24px;
+      flex-wrap: wrap;
+      gap: 12px 24px;
       margin-bottom: 20px;
       padding: 12px 16px;
     }


### PR DESCRIPTION
Add flex-wrap to stats bar so indicators wrap to a second row on narrow screens instead of overflowing.

Closes #95