### PR TITLE
Add context identifier to service calls for external automation detection

### DIFF
--- a/custom_components/roommind/const.py
+++ b/custom_components/roommind/const.py
@@ -4,6 +4,7 @@ import time
 from typing import NamedTuple
 
 from homeassistant.const import Platform
+from homeassistant.core import Context
 
 DOMAIN = "roommind"
 VERSION = "1.5.2-beta.1"
@@ -40,6 +41,16 @@ DEFAULT_COMFORT_HEAT = 21.0
 DEFAULT_COMFORT_COOL = 24.0
 DEFAULT_ECO_HEAT = 17.0
 DEFAULT_ECO_COOL = 27.0
+
+
+# Context identifier for RoomMind-initiated service calls.
+# Automations can check: trigger.context.parent_id == "roommind"
+ROOMMIND_CONTEXT_ID = "roommind"
+
+
+def make_roommind_context() -> Context:
+    """Create a HA Context tagged as originating from RoomMind."""
+    return Context(parent_id=ROOMMIND_CONTEXT_ID)
 
 
 class TargetTemps(NamedTuple):

--- a/custom_components/roommind/control/mpc_controller.py
+++ b/custom_components/roommind/control/mpc_controller.py
@@ -24,6 +24,7 @@ from ..const import (
     MODE_HEATING,
     MODE_IDLE,
     TargetTemps,
+    make_roommind_context,
 )
 from ..utils.device_utils import (
     DEFAULT_IDLE_SETBACK_OFFSET,
@@ -104,6 +105,7 @@ async def async_turn_off_climate(
                 "set_hvac_mode",
                 {"entity_id": entity_id, "hvac_mode": "off"},
                 blocking=True,
+                context=make_roommind_context(),
             )
             _last_commands[entity_id] = _cache_entry("set_hvac_mode", {"hvac_mode": "off"})
         except Exception:  # noqa: BLE001
@@ -177,6 +179,7 @@ async def async_turn_off_climate(
             "set_temperature",
             svc_data,
             blocking=True,
+            context=make_roommind_context(),
         )
         _last_commands[entity_id] = _cache_entry("set_temperature", svc_data)
     except Exception:  # noqa: BLE001
@@ -271,6 +274,7 @@ async def async_idle_device(
                 "set_temperature",
                 {"entity_id": entity_id, "temperature": ha_t},
                 blocking=True,
+                context=make_roommind_context(),
             )
             _last_commands[entity_id] = _cache_entry("set_temperature", {"temperature": ha_t})
         except Exception:  # noqa: BLE001
@@ -319,6 +323,7 @@ async def async_idle_device(
             "set_hvac_mode",
             {"entity_id": entity_id, "hvac_mode": "fan_only"},
             blocking=True,
+            context=make_roommind_context(),
         )
         _last_commands[entity_id] = _cache_entry("set_hvac_mode", {"hvac_mode": "fan_only"})
     except Exception:  # noqa: BLE001
@@ -339,6 +344,7 @@ async def async_idle_device(
                     "set_fan_mode",
                     {"entity_id": entity_id, "fan_mode": idle_fan_mode},
                     blocking=True,
+                    context=make_roommind_context(),
                 )
             except Exception:  # noqa: BLE001
                 _LOGGER.warning(
@@ -1421,7 +1427,13 @@ class MPCController:
             return
 
         try:
-            await self.hass.services.async_call("climate", service, data, blocking=True)
+            await self.hass.services.async_call(
+                "climate",
+                service,
+                data,
+                blocking=True,
+                context=make_roommind_context(),
+            )
             if eid:
                 _last_commands[eid] = _cache_entry(service, data)
         except Exception:  # noqa: BLE001

--- a/custom_components/roommind/managers/valve_manager.py
+++ b/custom_components/roommind/managers/valve_manager.py
@@ -11,6 +11,7 @@ from ..const import (
     DEFAULT_VALVE_PROTECTION_INTERVAL,
     HEATING_BOOST_TARGET,
     VALVE_PROTECTION_CYCLE_DURATION,
+    make_roommind_context,
 )
 from ..control.mpc_controller import async_turn_off_climate, resolve_hvac_mode
 from ..utils.device_utils import get_trv_eids
@@ -124,6 +125,7 @@ class ValveManager:
                         "set_hvac_mode",
                         {"entity_id": eid, "hvac_mode": vp_resolved},
                         blocking=True,
+                        context=make_roommind_context(),
                     )
                     boost_temp = celsius_to_ha_temp(self.hass, HEATING_BOOST_TARGET)
                     if eid_state:
@@ -142,6 +144,7 @@ class ValveManager:
                                 "target_temp_high": max(boost_temp, cur_high),
                             },
                             blocking=True,
+                            context=make_roommind_context(),
                         )
                     else:
                         await self.hass.services.async_call(
@@ -149,6 +152,7 @@ class ValveManager:
                             "set_temperature",
                             {"entity_id": eid, "temperature": boost_temp},
                             blocking=True,
+                            context=make_roommind_context(),
                         )
                     self._cycling[eid] = now
                     idle_days = int((now - last) / 86400) if last else 0

--- a/tests/control/test_apply.py
+++ b/tests/control/test_apply.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
@@ -261,6 +261,7 @@ async def test_turn_off_climate_normal_device():
         "set_hvac_mode",
         {"entity_id": "climate.trv", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -279,6 +280,7 @@ async def test_turn_off_climate_heat_only_uses_min_temp():
         "set_temperature",
         {"entity_id": "climate.trv", "temperature": 5.0},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -297,6 +299,7 @@ async def test_turn_off_climate_cool_only_uses_max_temp():
         "set_temperature",
         {"entity_id": "climate.ac", "temperature": 30.0},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -328,6 +331,7 @@ async def test_turn_off_climate_empty_modes_uses_off():
         "set_hvac_mode",
         {"entity_id": "climate.trv", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -346,6 +350,7 @@ async def test_turn_off_climate_no_modes_attr_uses_off():
         "set_hvac_mode",
         {"entity_id": "climate.trv", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 

--- a/tests/control/test_fan_mode.py
+++ b/tests/control/test_fan_mode.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
@@ -40,6 +40,7 @@ async def test_async_idle_device_off():
         "set_hvac_mode",
         {"entity_id": "climate.ac1", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -85,6 +86,7 @@ async def test_async_idle_device_fan_only_unsupported():
         "set_hvac_mode",
         {"entity_id": "climate.ac1", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -151,6 +153,7 @@ async def test_async_idle_device_no_device_config():
         "set_hvac_mode",
         {"entity_id": "climate.unknown", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -464,6 +467,7 @@ async def test_async_idle_device_setback_no_state():
         "set_hvac_mode",
         {"entity_id": "climate.ac1", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -488,6 +492,7 @@ async def test_async_idle_device_setback_auto_mode_fallback():
         "set_hvac_mode",
         {"entity_id": "climate.ac1", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -511,6 +516,7 @@ async def test_async_idle_device_setback_no_targets():
         "set_hvac_mode",
         {"entity_id": "climate.ac1", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 
@@ -536,6 +542,7 @@ async def test_async_idle_device_setback_heat_mode_no_heat_target():
         "set_hvac_mode",
         {"entity_id": "climate.ac1", "hvac_mode": "off"},
         blocking=True,
+        context=ANY,
     )
 
 

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -69,12 +69,14 @@ class TestRoomMindCoordinator:
             "set_hvac_mode",
             {"entity_id": "climate.living_room", "hvac_mode": "heat"},
             blocking=True,
+            context=ANY,
         )
         assert climate_calls[1] == call(
             "climate",
             "set_temperature",
             {"entity_id": "climate.living_room", "temperature": 30},
             blocking=True,
+            context=ANY,
         )
 
     @pytest.mark.asyncio

--- a/tests/coordinator/test_valve_protection.py
+++ b/tests/coordinator/test_valve_protection.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import ANY, AsyncMock, MagicMock, call
 
 import pytest
 
@@ -102,6 +102,7 @@ class TestValveProtection:
                 "set_hvac_mode",
                 {"entity_id": "climate.living_room", "hvac_mode": "off"},
                 blocking=True,
+                context=ANY,
             )
         ]
         assert len(off_calls) >= 1
@@ -154,6 +155,7 @@ class TestValveProtection:
                 "set_hvac_mode",
                 {"entity_id": "climate.living_room", "hvac_mode": "off"},
                 blocking=True,
+                context=ANY,
             )
         ]
         assert len(climate_off_calls) == 0

--- a/tests/coordinator/test_window_pause.py
+++ b/tests/coordinator/test_window_pause.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -55,6 +55,7 @@ class TestRoomMindCoordinator:
                 "set_hvac_mode",
                 {"entity_id": "climate.living_room", "hvac_mode": "off"},
                 blocking=True,
+                context=ANY,
             )
         ]
         assert len(hvac_off_calls) >= 1


### PR DESCRIPTION
## What

This PR adds a context with parent_id: "roommind" to all climate.set_temperature and climate.set_hvac_mode service calls made by RoomMind. This allows Home Assistant automations to reliably identify RoomMind as the source of a state change.

## Why

This enables reliable "manual override until next schedule" workflows without fragile workarounds like temperature thresholds in automations because you can easily detect the source of the temp change within the automation

condition:
  # Only trigger when the change was NOT made by RoomMind
  - condition: template
    value_template: >
      {{ trigger.to_state.context.parent_id != 'roommind' }}

## Checklist

- [x] Backend tests pass (`pytest tests/ -v`)
- [x] Frontend builds without errors (`cd frontend && npm run build`)
No strings needed
No UI changes needed
