### PR TITLE
fix: skip open_delay for windows already open at startup (#181)

### DIFF
--- a/custom_components/roommind/managers/window_manager.py
+++ b/custom_components/roommind/managers/window_manager.py
@@ -12,6 +12,7 @@ class WindowManager:
         self._open_since: dict[str, float] = {}
         self._closed_since: dict[str, float] = {}
         self._paused: dict[str, bool] = {}
+        self._seen: set[str] = set()
 
     def is_paused(self, area_id: str) -> bool:
         """Return True if climate control is paused due to open window."""
@@ -24,14 +25,23 @@ class WindowManager:
         """
         now = time.time()
         was_paused = self._paused.get(area_id, False)
+        first_observation = area_id not in self._seen
+        self._seen.add(area_id)
 
         if raw_open:
             self._closed_since.pop(area_id, None)
             if not was_paused:
-                if area_id not in self._open_since:
-                    self._open_since[area_id] = now
-                if now - self._open_since[area_id] >= open_delay:
+                if first_observation:
+                    # Window already open on first observation (e.g. after HA
+                    # restart).  Skip open_delay — the window has been open for
+                    # an unknown duration that certainly exceeds any configured
+                    # delay.
                     self._paused[area_id] = True
+                else:
+                    if area_id not in self._open_since:
+                        self._open_since[area_id] = now
+                    if now - self._open_since[area_id] >= open_delay:
+                        self._paused[area_id] = True
         else:
             self._open_since.pop(area_id, None)
             if was_paused:
@@ -48,3 +58,4 @@ class WindowManager:
         self._open_since.pop(area_id, None)
         self._closed_since.pop(area_id, None)
         self._paused.pop(area_id, None)
+        self._seen.discard(area_id)

--- a/tests/coordinator/test_window_pause.py
+++ b/tests/coordinator/test_window_pause.py
@@ -174,6 +174,8 @@ class TestRoomMindCoordinator:
         hass.services.async_call = AsyncMock()
 
         coordinator = _create_coordinator(hass, mock_config_entry)
+        # Mark room as already known (simulates prior cycle with window closed)
+        coordinator._window_manager._seen.add("living_room_abc12345")
         data = await coordinator._async_update_data()
 
         room_state = data["rooms"]["living_room_abc12345"]
@@ -200,6 +202,7 @@ class TestRoomMindCoordinator:
 
         coordinator = _create_coordinator(hass, mock_config_entry)
         # Pre-set: window has been open for 130s (exceeds 120s delay)
+        coordinator._window_manager._seen.add("living_room_abc12345")
         coordinator._window_manager._open_since["living_room_abc12345"] = time.time() - 130
         data = await coordinator._async_update_data()
 
@@ -287,6 +290,8 @@ class TestRoomMindCoordinator:
         hass.services.async_call = AsyncMock()
 
         coordinator = _create_coordinator(hass, mock_config_entry)
+        # Mark room as already known (simulates prior cycle with window closed)
+        coordinator._window_manager._seen.add("living_room_abc12345")
 
         with patch.object(
             coordinator._model_manager,
@@ -438,6 +443,8 @@ class TestRoomMindCoordinator:
         hass.services.async_call = AsyncMock()
 
         coordinator = _create_coordinator(hass, mock_config_entry)
+        # Mark room as already known (simulates prior cycle with window closed)
+        coordinator._window_manager._seen.add("living_room_abc12345")
 
         # Window opens
         window_state = MagicMock()
@@ -481,3 +488,4 @@ class TestRoomMindCoordinator:
         assert area_id not in coordinator._window_manager._open_since
         assert area_id not in coordinator._window_manager._closed_since
         assert area_id not in coordinator._window_manager._paused
+        assert area_id not in coordinator._window_manager._seen

--- a/tests/integration/test_window_pause.py
+++ b/tests/integration/test_window_pause.py
@@ -60,6 +60,8 @@ class TestWindowPause:
         """With a 60s open delay, window opens but heating continues on first cycle."""
         room = {**ROOM_WITH_WINDOW, "window_open_delay": 60}
         await setup_room(real_store, room)
+        # Mark room as already known (simulates prior cycle with window closed)
+        coordinator._window_manager._seen.add("living_room")
         coordinator.hass.states.get = MagicMock(
             side_effect=make_hass_states(
                 extra={"binary_sensor.window_living": "on"},

--- a/tests/managers/test_window_manager.py
+++ b/tests/managers/test_window_manager.py
@@ -25,6 +25,10 @@ def test_open_delay_not_yet_reached():
     """Window opens with open_delay=30, update within 30s. Not paused yet."""
     mgr = WindowManager()
     with patch("custom_components.roommind.managers.window_manager.time") as mock_time:
+        # Establish room as known (window closed initially)
+        mock_time.time.return_value = 900.0
+        mgr.update("living_room", raw_open=False, open_delay=30, close_delay=0)
+
         mock_time.time.return_value = 1000.0
         result = mgr.update("living_room", raw_open=True, open_delay=30, close_delay=0)
         assert result is False
@@ -41,6 +45,10 @@ def test_open_delay_reached():
     """Window opens with open_delay=30, update after 30s. Now paused."""
     mgr = WindowManager()
     with patch("custom_components.roommind.managers.window_manager.time") as mock_time:
+        # Establish room as known (window closed initially)
+        mock_time.time.return_value = 900.0
+        mgr.update("living_room", raw_open=False, open_delay=30, close_delay=0)
+
         mock_time.time.return_value = 1000.0
         mgr.update("living_room", raw_open=True, open_delay=30, close_delay=0)
         assert mgr.is_paused("living_room") is False
@@ -206,3 +214,72 @@ def test_multiple_windows_all_closed():
     result = mgr.update("living_room", raw_open=False, open_delay=0, close_delay=0)
     assert result is False
     assert mgr.is_paused("living_room") is False
+
+
+def test_window_already_open_at_startup_skips_delay():
+    """Window already open on first observation (e.g. after HA restart) skips open_delay."""
+    mgr = WindowManager()
+    with patch("custom_components.roommind.managers.window_manager.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        # First observation with window already open and a large open_delay
+        result = mgr.update("living_room", raw_open=True, open_delay=300, close_delay=0)
+        # Should be immediately paused despite 300s open_delay
+        assert result is True
+        assert mgr.is_paused("living_room") is True
+
+
+def test_window_opens_after_startup_respects_delay():
+    """Window closed on first observation, then opens later — normal delay applies."""
+    mgr = WindowManager()
+    with patch("custom_components.roommind.managers.window_manager.time") as mock_time:
+        # First observation: window closed
+        mock_time.time.return_value = 1000.0
+        mgr.update("living_room", raw_open=False, open_delay=30, close_delay=0)
+        assert mgr.is_paused("living_room") is False
+
+        # Window opens later — normal delay should apply
+        mock_time.time.return_value = 1100.0
+        result = mgr.update("living_room", raw_open=True, open_delay=30, close_delay=0)
+        assert result is False  # not yet, delay not elapsed
+
+        mock_time.time.return_value = 1130.0
+        result = mgr.update("living_room", raw_open=True, open_delay=30, close_delay=0)
+        assert result is True  # now 30s have passed
+
+
+def test_window_already_open_at_startup_close_delay_still_works():
+    """After startup-paused, closing respects close_delay normally."""
+    mgr = WindowManager()
+    with patch("custom_components.roommind.managers.window_manager.time") as mock_time:
+        # Startup: window already open → immediate pause
+        mock_time.time.return_value = 1000.0
+        mgr.update("living_room", raw_open=True, open_delay=60, close_delay=30)
+        assert mgr.is_paused("living_room") is True
+
+        # Window closes
+        mock_time.time.return_value = 1010.0
+        result = mgr.update("living_room", raw_open=False, open_delay=60, close_delay=30)
+        assert result is True  # still paused during close_delay
+
+        mock_time.time.return_value = 1040.0
+        result = mgr.update("living_room", raw_open=False, open_delay=60, close_delay=30)
+        assert result is False  # 30s close_delay elapsed
+
+
+def test_remove_room_resets_seen_state():
+    """After remove_room, the next observation is treated as first again."""
+    mgr = WindowManager()
+    with patch("custom_components.roommind.managers.window_manager.time") as mock_time:
+        mock_time.time.return_value = 1000.0
+        # Initial: window open → immediate pause (first observation)
+        mgr.update("living_room", raw_open=True, open_delay=60, close_delay=0)
+        assert mgr.is_paused("living_room") is True
+
+        # Remove room
+        mgr.remove_room("living_room")
+        assert mgr.is_paused("living_room") is False
+
+        # Re-add: window open again → should be treated as first observation
+        mock_time.time.return_value = 2000.0
+        result = mgr.update("living_room", raw_open=True, open_delay=60, close_delay=0)
+        assert result is True  # immediate pause again


### PR DESCRIPTION
## Summary
- After HA reboot, WindowManager now immediately pauses climate when a window is already open, skipping the open_delay
- Normal open_delay still applies for windows that open after startup
- Fixes #181

## Test plan
- [ ] Verify new unit tests pass in CI
- [ ] Configure a room with window sensor and non-zero open_delay
- [ ] With window open, restart HA — climate should pause immediately