### PR TITLE
chore: add vscode tasks for easier test execution

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Test: Run all tests",
+      "type": "shell",
+      "command": "${workspaceFolder}/.venv/bin/pytest",
+      "args": ["tests/", "-v", "--tb=short"],
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": {
+        "pattern": {
+          "regexp": "^(.+?):(\\d+):\\s+(FAILED|ERROR)",
+          "file": 1,
+          "location": 2
+        }
+      }
+    },
+    {
+      "label": "Test: Run with coverage",
+      "type": "shell",
+      "command": "${workspaceFolder}/.venv/bin/pytest",
+      "args": ["tests/", "--cov=custom_components/roommind", "--cov-report=html", "--cov-report=term-missing"],
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

With this PR I´d like to add default tasks for VSCode to make running tests easier.

## Why

easier testing of the code by simply using "Terminal"->"Run Task..."
personally i find it easier to have some recurring actions defined as tasks in VSCode.

I´m using the proposed file in other projects of mine and think of it as being quite useful ;)

## Checklist

- [x] Backend tests pass (`pytest tests/ -v`)
- [x] Frontend builds without errors (`cd frontend && npm run build`)
- [ ] New strings added to both `en.json` and `de.json` (if applicable)
- [ ] Tested on mobile layout (if UI change)
