### PR TITLE
docs: clarify Priority slider behavior and explain device control modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The Extended Kalman Filter observes temperature changes and learns each room's h
 
 Until calibrated (~60 idle + ~20 active samples), RoomMind falls back to simple on/off control with hysteresis.
 
+For a more detailed explanation of the `Priority` slider, device types, setpoint modes, idle behavior, and smart source selection, see the [Control and Device Guide](docs/control-and-devices.md).
+
 ## Entities Created
 
 | Entity | Description |

--- a/docs/control-and-devices.md
+++ b/docs/control-and-devices.md
@@ -92,6 +92,20 @@ Important:
 - the setback offset is currently fixed at `2°C`
 - it is **not configurable** in the current UI
 
+## Idle Behavior for Thermostats: Off, Low
+
+`When idle` also applies to `Thermostat` / TRV entries, with different options.
+
+### Turn off
+
+RoomMind sends the TRV to its `off` state.
+
+### Low
+
+RoomMind keeps the TRV in its current heating mode but lowers the setpoint to the device's minimum temperature.
+
+Useful for battery-powered Zigbee TRVs that enter deep sleep when set to `off` and then stop reacting to commands. `Low` keeps the valve responsive while effectively stopping heating.
+
 ## Smart Source Selection
 
 `Smart source selection` only appears when a room has:

--- a/docs/control-and-devices.md
+++ b/docs/control-and-devices.md
@@ -1,0 +1,109 @@
+# Control And Device Guide
+
+This page explains RoomMind's control settings and related device options.
+
+## What Priority Does
+
+In `Settings -> Control -> Priority`, the slider balances comfort against runtime/energy use for MPC.
+
+- Toward `Comfort`: RoomMind reacts earlier and works harder to stay close to the target temperature.
+- Toward `Efficiency`: RoomMind allows more drift around the target to reduce heating/cooling runtime.
+
+This setting does **not** change your schedule targets, overrides, comfort temperature, or eco temperature. It only changes how aggressively MPC tries to reach and hold those targets.
+
+## Thermostat vs Climate Device
+
+Both options are Home Assistant `climate.*` entities, but RoomMind treats them differently:
+
+- `Thermostat`: a radiator thermostat / TRV style device.
+- `Climate Device`: an AC, heat pump, or other climate entity used for cooling or forced-air heating.
+
+In practice:
+
+- Choose `Thermostat` for radiator valves and similar heating-only valve devices.
+- Choose `Climate Device` for ACs, minisplits, heat pumps, and other self-contained HVAC units.
+
+## Full Control vs Managed
+
+An external room temperature sensor is the key split:
+
+- `Full Control`: RoomMind uses the external sensor as the room truth and can actively shape device output.
+- `Managed`: without an external room sensor, RoomMind sends target temperatures but the device mostly regulates itself using its own internal sensor.
+
+This matters for the options below.
+
+## Setpoint Mode: Proportional vs Direct
+
+`Setpoint mode` is relevant for thermostat/TRV devices in `Full Control` rooms.
+
+### Proportional
+
+RoomMind calculates the required heating power, then sends a boosted device setpoint to achieve roughly that output.
+
+Example:
+
+- room target is `21°C`
+- more heat is needed
+- RoomMind may send `26-28°C` to the TRV to force the valve open harder
+
+Best for:
+
+- radiator valves / TRVs
+- devices that need an exaggerated setpoint to actually deliver heat
+
+### Direct
+
+RoomMind sends the real target temperature and lets the device regulate itself.
+
+Best for:
+
+- space heaters
+- pellet stoves
+- devices with their own thermostat logic that should stay in control internally
+
+## Idle Behavior: Off, Fan Only, Setback
+
+`When idle` applies to `Climate Device` entries.
+
+### Turn off
+
+RoomMind turns the device off, or falls back to the device's minimum/off-like behavior if true off is not supported.
+
+### Fan only
+
+RoomMind keeps the device running in fan mode without active heating/cooling.
+
+Useful when you want:
+
+- air circulation
+- less harsh on/off transitions
+
+### Setback
+
+RoomMind keeps the current HVAC mode active, but moves the target away from the room target:
+
+- heating setback = `heat target - 2°C`
+- cooling setback = `cool target + 2°C`
+
+This lets the device back off instead of shutting off completely.
+
+Important:
+
+- the setback offset is currently fixed at `2°C`
+- it is **not configurable** in the current UI
+
+## Smart Source Selection
+
+`Smart source selection` only appears when a room has:
+
+- at least one `Thermostat` / TRV
+- at least one `Climate Device` / AC
+- an external temperature sensor
+
+In that case RoomMind can decide which source should heat:
+
+- TRV / boiler side
+- AC / heat pump side
+- or both, when the gap is large
+
+It uses temperature gap and outdoor conditions to make that choice.

--- a/frontend/src/components/rs-room-detail.ts
+++ b/frontend/src/components/rs-room-detail.ts
@@ -29,6 +29,9 @@ import { fireSaveStatus } from "../utils/events";
 import { resolveHeatingSystemType } from "../utils/device-utils";
 import type { RsOverrideSection } from "./rs-override-section";
 
+const CONTROL_DOCS_URL =
+  "https://github.com/snazzybean/roommind/blob/main/docs/control-and-devices.md";
+
 @customElement("rs-room-detail")
 export class RsRoomDetail extends LitElement {
   @property({ attribute: false }) public area!: HassArea;
@@ -182,6 +185,18 @@ export class RsRoomDetail extends LitElement {
     }
 
     .exceptions-link:hover {
+      text-decoration: underline;
+    }
+
+    .helper-link {
+      display: inline-block;
+      margin-top: 12px;
+      color: var(--primary-color);
+      font-size: 12px;
+      text-decoration: none;
+    }
+
+    .helper-link:hover {
       text-decoration: underline;
     }
   `;
@@ -452,6 +467,7 @@ export class RsRoomDetail extends LitElement {
                 <rs-section-card
                   icon="mdi:power-plug"
                   .heading=${localize("room.section.devices", this.hass.language)}
+                  hasInfo
                   editable
                   .editing=${this._editingDevices}
                   .doneLabel=${localize("devices.done", this.hass.language)}
@@ -462,6 +478,23 @@ export class RsRoomDetail extends LitElement {
                     this._editingDevices = false;
                   }}
                 >
+                  <div slot="info">
+                    <b>${localize("devices.info.types_title", this.hass.language)}</b><br />
+                    ${localize("devices.info.types_body", this.hass.language)}
+                    <br /><br />
+                    <b>${localize("devices.info.control_title", this.hass.language)}</b><br />
+                    ${localize("devices.info.control_body", this.hass.language)}
+                    <br /><br />
+                    <b>${localize("devices.info.modes_title", this.hass.language)}</b><br />
+                    ${localize("devices.info.modes_body", this.hass.language)}
+                    <br /><br />
+                    <b>${localize("devices.info.heat_source_title", this.hass.language)}</b><br />
+                    ${localize("devices.info.heat_source_body", this.hass.language)}
+                    <br />
+                    <a class="helper-link" href=${CONTROL_DOCS_URL} target="_blank" rel="noreferrer">
+                      ${localize("common.learn_more", this.hass.language)}
+                    </a>
+                  </div>
                   <rs-device-section
                     .hass=${this.hass}
                     .area=${this.area}

--- a/frontend/src/components/rs-room-detail.ts
+++ b/frontend/src/components/rs-room-detail.ts
@@ -491,7 +491,12 @@ export class RsRoomDetail extends LitElement {
                     <b>${localize("devices.info.heat_source_title", this.hass.language)}</b><br />
                     ${localize("devices.info.heat_source_body", this.hass.language)}
                     <br />
-                    <a class="helper-link" href=${CONTROL_DOCS_URL} target="_blank" rel="noreferrer">
+                    <a
+                      class="helper-link"
+                      href=${CONTROL_DOCS_URL}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
                       ${localize("common.learn_more", this.hass.language)}
                     </a>
                   </div>

--- a/frontend/src/components/settings/rs-settings-control.ts
+++ b/frontend/src/components/settings/rs-settings-control.ts
@@ -9,6 +9,9 @@ import { localize } from "../../utils/localize";
 import { getSelectValue } from "../../utils/events";
 import { toDisplay, toCelsius, tempUnit, tempStep, tempRange } from "../../utils/temperature";
 
+const CONTROL_DOCS_URL =
+  "https://github.com/snazzybean/roommind/blob/main/docs/control-and-devices.md";
+
 @customElement("rs-settings-control")
 export class RsSettingsControl extends RsSettingsBase {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -54,6 +57,10 @@ export class RsSettingsControl extends RsSettingsBase {
           />
           <span class="slider-label">${localize("settings.comfort_weight_comfort", l)}</span>
         </div>
+        <p class="hint helper-text">${localize("settings.comfort_weight_hint", l)}</p>
+        <a class="helper-link" href=${CONTROL_DOCS_URL} target="_blank" rel="noreferrer">
+          ${localize("common.learn_more", l)}
+        </a>
       </div>
 
       <div class="settings-section">
@@ -143,6 +150,9 @@ export class RsSettingsControl extends RsSettingsBase {
         font-size: 13px;
         margin: 0 0 12px;
       }
+      .helper-text {
+        margin: 10px 0 0;
+      }
       .section-label {
         display: block;
         margin-bottom: 8px;
@@ -175,6 +185,16 @@ export class RsSettingsControl extends RsSettingsBase {
         font-size: 12px;
         color: var(--secondary-text-color);
         white-space: nowrap;
+      }
+      .helper-link {
+        display: inline-block;
+        margin-top: 6px;
+        font-size: 12px;
+        color: var(--primary-color);
+        text-decoration: none;
+      }
+      .helper-link:hover {
+        text-decoration: underline;
       }
     `,
   ];

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -9,6 +9,7 @@
 
   "badge.beta": "Beta",
   "badge.beta_hint": "Dieses Feature ist in der Beta-Phase und kann sich in zukünftigen Updates noch ändern.",
+  "common.learn_more": "Mehr erfahren",
 
   "panel.stat.rooms": "Räume",
   "panel.stat.heating": "Heizen",
@@ -191,6 +192,14 @@
   "devices.setpoint_mode_hint": "Verwende Direkt für Heizlüfter oder Pelletöfen mit eigenem Thermostat. Proportional ist optimal für Heizkörperventile (TRVs).",
   "devices.valve_protection_excluded": "Vom Ventilschutz ausgenommen",
   "devices.valve_protection_exclude_hint": "Dieses Gerät wird nicht vom Ventilschutz bewegt (z.B. virtuelle Kessel-Entitäten)",
+  "devices.info.types_title": "Gerätetypen",
+  "devices.info.types_body": "Thermostat bedeutet Heizkörperthermostat / TRV. Klimagerät bedeutet AC, Wärmepumpe oder eine andere Klima-Entität für Kühlung oder Warmluftheizung. Beides sind Home-Assistant-Klima-Entitäten; der Unterschied liegt darin, wie RoomMind sie ansteuert.",
+  "devices.info.control_title": "Wie RoomMind sie steuert",
+  "devices.info.control_body": "Der Sollwert-Modus gilt nur für Thermostate in Räumen mit Full Control und externem Temperatursensor. Verwende Proportional, wenn RoomMind die Heizleistung über angehobene Sollwerte steuern soll. Verwende Direkt, wenn das Gerät selbst um den echten Zielwert regeln soll.",
+  "devices.info.modes_title": "Verhalten im Leerlauf",
+  "devices.info.modes_body": "Im Leerlauf gilt nur für Klimageräte. Ausschalten schaltet das Gerät aus. Nur Ventilator hält die Luftzirkulation ohne Heizen oder Kühlen aufrecht. Absenkung lässt den aktuellen Modus aktiv, verschiebt den Sollwert aber um 2°C vom Raumziel weg. Dieser Offset ist derzeit fest.",
+  "devices.info.heat_source_title": "Intelligente Quellenwahl",
+  "devices.info.heat_source_body": "Diese Funktion erscheint nur, wenn ein Raum sowohl ein Thermostat/TRV als auch ein Klimagerät und zusätzlich einen externen Temperatursensor hat. RoomMind kann dann je nach Temperaturdifferenz und Außenbedingungen auswählen, welche Quelle das Heizen übernimmt.",
 
   "hero.window_open": "Fenster offen – pausiert",
   "card.window_open": "Fenster offen",
@@ -320,6 +329,7 @@
   "settings.comfort_weight": "Priorität",
   "settings.comfort_weight_comfort": "Komfort",
   "settings.comfort_weight_efficiency": "Effizienz",
+  "settings.comfort_weight_hint": "Gewichtet Temperaturgenauigkeit gegen Energieverbrauch. Komfort reagiert früher und bleibt näher am Zielwert. Effizienz erlaubt mehr Abweichung, um Heiz- und Kühllaufzeiten zu reduzieren.",
   "settings.weather_entity": "Wettervorhersage",
   "settings.weather_entity_hint": "Optional: ermöglicht vorausschauende Außentemperaturplanung",
   "settings.prediction_enabled": "Temperaturvorhersage",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -197,7 +197,7 @@
   "devices.info.control_title": "Wie RoomMind sie steuert",
   "devices.info.control_body": "Der Sollwert-Modus gilt nur für Thermostate in Räumen mit Full Control und externem Temperatursensor. Verwende Proportional, wenn RoomMind die Heizleistung über angehobene Sollwerte steuern soll. Verwende Direkt, wenn das Gerät selbst um den echten Zielwert regeln soll.",
   "devices.info.modes_title": "Verhalten im Leerlauf",
-  "devices.info.modes_body": "Im Leerlauf gilt nur für Klimageräte. Ausschalten schaltet das Gerät aus. Nur Ventilator hält die Luftzirkulation ohne Heizen oder Kühlen aufrecht. Absenkung lässt den aktuellen Modus aktiv, verschiebt den Sollwert aber um 2°C vom Raumziel weg. Dieser Offset ist derzeit fest.",
+  "devices.info.modes_body": "Im Leerlauf gilt nur für Klimageräte. Ausschalten schaltet das Gerät aus. Nur Ventilator hält die Luftzirkulation ohne Heizen oder Kühlen aufrecht. Absenkung lässt den aktuellen Modus aktiv, verschiebt den Sollwert aber um 2°C vom Raumziel weg. Dieser Offset ist derzeit fest. Für Thermostate hält Niedrig den TRV aktiv auf minimalem Sollwert statt ihn auszuschalten, nützlich für batteriebetriebene Zigbee-TRVs, die beim Ausschalten in den Tiefschlaf gehen.",
   "devices.info.heat_source_title": "Intelligente Quellenwahl",
   "devices.info.heat_source_body": "Diese Funktion erscheint nur, wenn ein Raum sowohl ein Thermostat/TRV als auch ein Klimagerät und zusätzlich einen externen Temperatursensor hat. RoomMind kann dann je nach Temperaturdifferenz und Außenbedingungen auswählen, welche Quelle das Heizen übernimmt.",
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -9,6 +9,7 @@
 
   "badge.beta": "Beta",
   "badge.beta_hint": "This feature is in beta and may change or be restructured in future updates.",
+  "common.learn_more": "Learn more",
 
   "panel.stat.rooms": "Rooms",
   "panel.stat.heating": "Heating",
@@ -191,6 +192,14 @@
   "devices.setpoint_mode_hint": "Use Direct for space heaters or pellet stoves with their own thermostat. Proportional is best for radiator valves (TRVs).",
   "devices.valve_protection_excluded": "Excluded from valve protection",
   "devices.valve_protection_exclude_hint": "This entity will not be cycled by valve protection (e.g. virtual boiler entities)",
+  "devices.info.types_title": "Device types",
+  "devices.info.types_body": "Thermostat means a radiator thermostat / TRV. Climate Device means an AC, heat pump, or other climate entity used for cooling or forced-air heating. Both are Home Assistant climate entities; the distinction is how RoomMind controls them.",
+  "devices.info.control_title": "How RoomMind controls them",
+  "devices.info.control_body": "Setpoint mode only applies to thermostats in Full Control rooms with an external temperature sensor. Use Proportional when RoomMind should drive heating output by sending boosted setpoints. Use Direct when the device should regulate itself around the real target temperature.",
+  "devices.info.modes_title": "Idle behavior",
+  "devices.info.modes_body": "When idle only applies to Climate Devices. Turn off powers the device down. Fan only keeps airflow without heating or cooling. Setback keeps the current mode active but moves the target 2°C away from the room target. This setback offset is currently fixed.",
+  "devices.info.heat_source_title": "Smart source selection",
+  "devices.info.heat_source_body": "This appears only when a room has both a thermostat/TRV and a Climate Device plus an external temperature sensor. RoomMind can then choose which source should handle heating based on temperature gap and outdoor conditions.",
 
   "hero.window_open": "Window open – paused",
   "card.window_open": "Window open",
@@ -320,6 +329,7 @@
   "settings.comfort_weight": "Priority",
   "settings.comfort_weight_comfort": "Comfort",
   "settings.comfort_weight_efficiency": "Efficiency",
+  "settings.comfort_weight_hint": "Balances temperature precision against energy use. Comfort reacts earlier and stays closer to target. Efficiency allows more drift to reduce heating/cooling runtime.",
   "settings.weather_entity": "Weather Forecast",
   "settings.weather_entity_hint": "Optional: enables predictive outdoor temperature planning",
   "settings.prediction_enabled": "Temperature prediction",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -197,7 +197,7 @@
   "devices.info.control_title": "How RoomMind controls them",
   "devices.info.control_body": "Setpoint mode only applies to thermostats in Full Control rooms with an external temperature sensor. Use Proportional when RoomMind should drive heating output by sending boosted setpoints. Use Direct when the device should regulate itself around the real target temperature.",
   "devices.info.modes_title": "Idle behavior",
-  "devices.info.modes_body": "When idle only applies to Climate Devices. Turn off powers the device down. Fan only keeps airflow without heating or cooling. Setback keeps the current mode active but moves the target 2°C away from the room target. This setback offset is currently fixed.",
+  "devices.info.modes_body": "When idle only applies to Climate Devices. Turn off powers the device down. Fan only keeps airflow without heating or cooling. Setback keeps the current mode active but moves the target 2°C away from the room target. This setback offset is currently fixed. For Thermostats, Low keeps the TRV active at its minimum setpoint instead of off, useful for battery-powered Zigbee TRVs that sleep when set to off.",
   "devices.info.heat_source_title": "Smart source selection",
   "devices.info.heat_source_body": "This appears only when a room has both a thermostat/TRV and a Climate Device plus an external temperature sensor. RoomMind can then choose which source should handle heating based on temperature gap and outdoor conditions.",
 


### PR DESCRIPTION
## Summary
Improve UI clarity around RoomMind control settings and device behavior by adding inline helper text, a dedicated control/device guide.

## What

- add a new docs page for RoomMind control and device behavior
- surface the new guidance directly in the UI from the Control settings and room Devices section
- link the guide from the README

## Why

I found hard to know what these parts of the system meant. I thought the priority slider was the other way around with regards to the control loop. I have an HVAC system that heats very effectively, and running that on 30C is quite hot. 
I also had trouble figuring out why the setpoint was set 2C below the target temperature, creating a saw-tooth behavior on certain days.

## Checklist

- [x] Backend tests pass (`pytest tests/ -v`)
- [x] Frontend builds without errors (`cd frontend && npm run build`)
- [x] New strings added to both `en.json` and `de.json` (if applicable)
   - _I don´t know German too well, so if the translations are bad, I blame ChatGPT :)_ 
- [x] Tested on mobile layout (if UI change)
