### PR TITLE
Fix panel breakage on Home Assistant 2026.6

### DIFF
--- a/frontend/src/components/rs-room-detail.ts
+++ b/frontend/src/components/rs-room-detail.ts
@@ -604,7 +604,7 @@ export class RsRoomDetail extends LitElement {
           icon="mdi:calendar"
           .heading=${localize("room.section.schedule", lang)}
           hasInfo
-          @dialog-closed=${this._closeEdit}
+          @rs-dialog-closed=${this._closeEdit}
         >
           <div slot="info">
             <p><strong>${localize("schedule.help_temps_title", lang)}</strong></p>
@@ -680,7 +680,7 @@ export class RsRoomDetail extends LitElement {
           icon="mdi:power-plug"
           .heading=${localize("room.section.devices", lang)}
           hasInfo
-          @dialog-closed=${this._closeEdit}
+          @rs-dialog-closed=${this._closeEdit}
         >
           <div slot="info">
             <b>${localize("devices.info.types_title", lang)}</b><br />
@@ -716,7 +716,7 @@ export class RsRoomDetail extends LitElement {
           open
           icon="mdi:thermometer"
           .heading=${localize("room.section.sensors", lang)}
-          @dialog-closed=${this._closeEdit}
+          @rs-dialog-closed=${this._closeEdit}
         >
           <rs-sensor-section
             .hass=${this.hass}
@@ -739,7 +739,7 @@ export class RsRoomDetail extends LitElement {
           icon="mdi:home-account"
           .heading=${localize("room.section.presence", lang)}
           hasInfo
-          @dialog-closed=${this._closeEdit}
+          @rs-dialog-closed=${this._closeEdit}
         >
           <div slot="info">
             <b>${localize("presence.room_help_header", lang)}</b><br />
@@ -766,7 +766,7 @@ export class RsRoomDetail extends LitElement {
           icon="mdi:blinds-horizontal"
           .heading=${localize("room.section.covers", lang)}
           hasInfo
-          @dialog-closed=${this._closeEdit}
+          @rs-dialog-closed=${this._closeEdit}
         >
           <div slot="info">
             <b>${localize("covers.info.selection_title", lang)}</b><br />
@@ -832,7 +832,7 @@ export class RsRoomDetail extends LitElement {
           open
           icon="mdi:swap-horizontal"
           .heading=${localize("room.section.heat_source", lang)}
-          @dialog-closed=${this._closeEdit}
+          @rs-dialog-closed=${this._closeEdit}
         >
           <rs-heat-source-section
             .hass=${this.hass}

--- a/frontend/src/components/shared/rs-edit-dialog.ts
+++ b/frontend/src/components/shared/rs-edit-dialog.ts
@@ -236,7 +236,13 @@ export class RsEditDialog extends LitElement {
 
   private _close() {
     this._infoExpanded = false;
-    this.dispatchEvent(new CustomEvent("dialog-closed", { bubbles: true, composed: true }));
+    // Namespaced event: HA reserves the bare "dialog-closed" name for its own
+    // dialog manager (read as `e.detail.dialog`). A composed event of that name
+    // with a null detail bubbles up to <home-assistant> and crashes HA's
+    // handler ("can't access property 'dialog', e.detail is null"), which broke
+    // the room edit dialogs after HA 2026's dialog rework. Use a RoomMind-
+    // specific name so it can never collide with HA's listener.
+    this.dispatchEvent(new CustomEvent("rs-dialog-closed", { bubbles: true, composed: true }));
   }
 }
 

--- a/frontend/src/ha-radio-polyfill.ts
+++ b/frontend/src/ha-radio-polyfill.ts
@@ -1,0 +1,73 @@
+/**
+ * Polyfill for `ha-radio`, removed in Home Assistant 2026.6.
+ *
+ * HA 2026.6 dropped the standalone `ha-radio` element in favour of the
+ * Web Awesome based `ha-radio-group` + `ha-radio-option` components
+ * (frontend component updates 2026.6). Custom panels that still render
+ * `<ha-radio>` end up with an undefined element — the radio control simply
+ * disappears, so option lists and settings toggles can no longer be chosen.
+ *
+ * This self-contained wrapper renders a native `<input type="radio">` and
+ * preserves the small subset of the mwc-radio API that RoomMind uses
+ * (checked, value, name, disabled). It re-emits a composed `change` event so
+ * existing `<ha-radio @change>` listeners keep working. Every RoomMind radio
+ * is a controlled control — `checked` is driven from component state and a
+ * selection flows back through events + re-render — so no cross-element
+ * single-selection coordination is needed.
+ *
+ * It is registered conditionally in `load-ha-elements.ts`, only when
+ * `ha-radio` is missing, so older HA versions keep their native element.
+ */
+import { LitElement, html, css, type TemplateResult } from "lit";
+import { property } from "lit/decorators.js";
+
+export class HaRadioPolyfill extends LitElement {
+  @property({ type: Boolean, reflect: true }) public checked = false;
+  @property({ type: Boolean, reflect: true }) public disabled = false;
+  @property({ type: String }) public name = "";
+  @property({ type: String }) public value = "";
+
+  static shadowRootOptions: ShadowRootInit = {
+    mode: "open",
+    delegatesFocus: true,
+  };
+
+  static styles = css`
+    :host {
+      display: inline-flex;
+      align-items: center;
+    }
+    input {
+      width: 18px;
+      height: 18px;
+      margin: 0;
+      accent-color: var(--primary-color, #03a9f4);
+      cursor: pointer;
+    }
+    input:disabled {
+      cursor: default;
+      opacity: 0.5;
+    }
+  `;
+
+  protected override render(): TemplateResult {
+    return html`
+      <input
+        type="radio"
+        .checked=${this.checked}
+        .value=${this.value}
+        name=${this.name || undefined}
+        ?disabled=${this.disabled}
+        @change=${this._onChange}
+      />
+    `;
+  }
+
+  private _onChange(e: Event): void {
+    this.checked = (e.target as HTMLInputElement).checked;
+    // Native `change` does not cross the shadow boundary, so re-emit one from
+    // the host. Listeners on `<ha-radio @change>` (e.g. rs-radio-group) then
+    // fire with `target.checked` / `target.value` reading from this element.
+    this.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+}

--- a/frontend/src/ha-radio-polyfill.ts
+++ b/frontend/src/ha-radio-polyfill.ts
@@ -68,6 +68,6 @@ export class HaRadioPolyfill extends LitElement {
     // Native `change` does not cross the shadow boundary, so re-emit one from
     // the host. Listeners on `<ha-radio @change>` (e.g. rs-radio-group) then
     // fire with `target.checked` / `target.value` reading from this element.
-    this.dispatchEvent(new Event("change", { bubbles: true }));
+    this.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
   }
 }

--- a/frontend/src/load-ha-elements.ts
+++ b/frontend/src/load-ha-elements.ts
@@ -6,6 +6,19 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any -- HA runtime APIs are untyped */
 export const loadHaElements = async (): Promise<void> => {
+  // HA 2026.6 removed the standalone `ha-radio` element (replaced by the
+  // Web Awesome `ha-radio-group`/`ha-radio-option`). Register a self-contained
+  // polyfill so existing `<ha-radio>` templates keep rendering. It depends on
+  // no other HA element, so register it up front — before the entity-picker
+  // fast-path return below — and only when `ha-radio` is genuinely missing,
+  // leaving older HA versions on their native element.
+  if (!customElements.get("ha-radio")) {
+    const { HaRadioPolyfill } = await import("./ha-radio-polyfill");
+    if (!customElements.get("ha-radio")) {
+      customElements.define("ha-radio", HaRadioPolyfill);
+    }
+  }
+
   if (customElements.get("ha-entity-picker")) return;
 
   // Step 1: Load base HA components via partial-panel-resolver.
@@ -73,22 +86,25 @@ export const loadHaElements = async (): Promise<void> => {
 
   await customElements.whenDefined("ha-card");
 
-  // Step 2b: HA 2026.5 removed `ha-textfield` (home-assistant/frontend#30349).
-  // If it is missing but the successor `ha-input` exists, register a
-  // wrapper so existing `<ha-textfield>` templates keep working. Older HA
-  // versions retain their native ha-textfield and fall through untouched.
+  // Step 2b: HA 2026.5 removed `ha-textfield` (home-assistant/frontend#30349)
+  // in favour of `ha-input`. Register a wrapper so existing `<ha-textfield>`
+  // templates keep working. Older HA versions retain their native
+  // ha-textfield and skip this block.
+  //
+  // We wait briefly for `ha-input` so the wrapper can upgrade immediately, but
+  // register regardless of whether that wait resolves: on HA 2026.6 the panel
+  // chain may import `ha-input` lazily (after our budget), and a missed
+  // registration leaves every text field — room comfort/eco temps included —
+  // invisible. A `<ha-input>` rendered before its definition simply upgrades
+  // once HA defines it, so unconditional registration is strictly safer.
   if (!customElements.get("ha-textfield")) {
-    try {
-      await Promise.race([
-        customElements.whenDefined("ha-input"),
-        new Promise<void>((_, rej) => setTimeout(() => rej(new Error("timeout")), 5000)),
-      ]);
-      const { HaTextfieldPolyfill } = await import("./ha-textfield-polyfill");
-      if (!customElements.get("ha-textfield")) {
-        customElements.define("ha-textfield", HaTextfieldPolyfill);
-      }
-    } catch {
-      // ha-input not available — ha-textfield templates will render empty
+    await Promise.race([
+      customElements.whenDefined("ha-input"),
+      new Promise<void>((r) => setTimeout(r, 5000)),
+    ]);
+    const { HaTextfieldPolyfill } = await import("./ha-textfield-polyfill");
+    if (!customElements.get("ha-textfield")) {
+      customElements.define("ha-textfield", HaTextfieldPolyfill);
     }
   }
 

--- a/frontend/src/load-ha-elements.ts
+++ b/frontend/src/load-ha-elements.ts
@@ -13,9 +13,15 @@ export const loadHaElements = async (): Promise<void> => {
   // fast-path return below — and only when `ha-radio` is genuinely missing,
   // leaving older HA versions on their native element.
   if (!customElements.get("ha-radio")) {
-    const { HaRadioPolyfill } = await import("./ha-radio-polyfill");
-    if (!customElements.get("ha-radio")) {
-      customElements.define("ha-radio", HaRadioPolyfill);
+    try {
+      const { HaRadioPolyfill } = await import("./ha-radio-polyfill");
+      if (!customElements.get("ha-radio")) {
+        customElements.define("ha-radio", HaRadioPolyfill);
+      }
+    } catch (err) {
+      // A failed polyfill load (chunk/network error) must not abort the rest
+      // of element initialisation below — radios degrade, panel survives.
+      console.warn("RoomMind: ha-radio polyfill failed to load", err);
     }
   }
 
@@ -29,9 +35,15 @@ export const loadHaElements = async (): Promise<void> => {
   // automatically once HA defines it, so registering eagerly is safe and avoids
   // delaying cold loads. Older HA versions keep their native ha-textfield.
   if (!customElements.get("ha-textfield")) {
-    const { HaTextfieldPolyfill } = await import("./ha-textfield-polyfill");
-    if (!customElements.get("ha-textfield")) {
-      customElements.define("ha-textfield", HaTextfieldPolyfill);
+    try {
+      const { HaTextfieldPolyfill } = await import("./ha-textfield-polyfill");
+      if (!customElements.get("ha-textfield")) {
+        customElements.define("ha-textfield", HaTextfieldPolyfill);
+      }
+    } catch (err) {
+      // As above: don't let a polyfill load failure block entity-picker /
+      // chart-base setup. Text fields degrade, the rest of the panel loads.
+      console.warn("RoomMind: ha-textfield polyfill failed to load", err);
     }
   }
 

--- a/frontend/src/load-ha-elements.ts
+++ b/frontend/src/load-ha-elements.ts
@@ -19,6 +19,22 @@ export const loadHaElements = async (): Promise<void> => {
     }
   }
 
+  // HA 2026.5 removed `ha-textfield` (home-assistant/frontend#30349) in favour
+  // of `ha-input`; register a wrapper so existing `<ha-textfield>` templates
+  // keep working. This MUST run before the entity-picker fast-path return
+  // below: on HA 2026.6 `ha-entity-picker` is already defined at panel start,
+  // so a registration placed after the return never runs and every text field
+  // (room comfort/eco temps included) stays invisible. We do not wait for
+  // `ha-input` here — the wrapper renders `<ha-input>`, which upgrades
+  // automatically once HA defines it, so registering eagerly is safe and avoids
+  // delaying cold loads. Older HA versions keep their native ha-textfield.
+  if (!customElements.get("ha-textfield")) {
+    const { HaTextfieldPolyfill } = await import("./ha-textfield-polyfill");
+    if (!customElements.get("ha-textfield")) {
+      customElements.define("ha-textfield", HaTextfieldPolyfill);
+    }
+  }
+
   if (customElements.get("ha-entity-picker")) return;
 
   // Step 1: Load base HA components via partial-panel-resolver.
@@ -85,28 +101,6 @@ export const loadHaElements = async (): Promise<void> => {
   }
 
   await customElements.whenDefined("ha-card");
-
-  // Step 2b: HA 2026.5 removed `ha-textfield` (home-assistant/frontend#30349)
-  // in favour of `ha-input`. Register a wrapper so existing `<ha-textfield>`
-  // templates keep working. Older HA versions retain their native
-  // ha-textfield and skip this block.
-  //
-  // We wait briefly for `ha-input` so the wrapper can upgrade immediately, but
-  // register regardless of whether that wait resolves: on HA 2026.6 the panel
-  // chain may import `ha-input` lazily (after our budget), and a missed
-  // registration leaves every text field — room comfort/eco temps included —
-  // invisible. A `<ha-input>` rendered before its definition simply upgrades
-  // once HA defines it, so unconditional registration is strictly safer.
-  if (!customElements.get("ha-textfield")) {
-    await Promise.race([
-      customElements.whenDefined("ha-input"),
-      new Promise<void>((r) => setTimeout(r, 5000)),
-    ]);
-    const { HaTextfieldPolyfill } = await import("./ha-textfield-polyfill");
-    if (!customElements.get("ha-textfield")) {
-      customElements.define("ha-textfield", HaTextfieldPolyfill);
-    }
-  }
 
   // Step 3: Load ha-date-range-picker (used by rs-analytics).
   if (!customElements.get("ha-date-range-picker")) {

--- a/frontend/src/utils/chart-builder.ts
+++ b/frontend/src/utils/chart-builder.ts
@@ -255,7 +255,7 @@ export function buildChartOptions(
           seriesId: string;
         }>,
       ) => {
-        if (!Array.isArray(params) || params.length === 0) return null;
+        if (!Array.isArray(params) || params.length === 0) return "";
         const date = new Date(params[0].value[0]);
         const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
         let markup = `<div style="font-weight:500;margin-bottom:4px">${time}</div>`;

--- a/frontend/src/utils/chart-builder.ts
+++ b/frontend/src/utils/chart-builder.ts
@@ -255,7 +255,7 @@ export function buildChartOptions(
           seriesId: string;
         }>,
       ) => {
-        if (!Array.isArray(params) || params.length === 0) return "";
+        if (!Array.isArray(params) || params.length === 0) return null;
         const date = new Date(params[0].value[0]);
         const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
         let markup = `<div style="font-weight:500;margin-bottom:4px">${time}</div>`;
@@ -312,7 +312,14 @@ export function buildChartOptions(
             }
           }
         }
-        return markup;
+        // HA 2026.6's ha-chart-base pipes the tooltip formatter result through
+        // Lit's render() (wrapLitTooltipFormatter). A returned string is
+        // rendered as escaped text — the raw HTML shows up as code. Returning
+        // an HTMLElement renders correctly there and is also a valid return
+        // value for ECharts' html tooltip on older HA, so both paths work.
+        const tooltipEl = document.createElement("div");
+        tooltipEl.innerHTML = markup;
+        return tooltipEl;
       },
     },
     grid: {


### PR DESCRIPTION
## What

Fixes the RoomMind panel breakage on Home Assistant 2026.6, caused by the
ongoing Web Awesome / Material 3 frontend migration:

- **`ha-radio` polyfill** — HA 2026.6 removed the standalone `ha-radio`
  element (replaced by `ha-radio-group`/`ha-radio-option`). Added a
  self-contained native-`<input type="radio">` wrapper, registered when the
  element is missing. Restores the control-mode selection ("Choose how
  RoomMind controls your climate devices") plus the sensor/device/cover radios.
- **Analytics tooltip** — `ha-chart-base` now pipes the tooltip formatter
  result through Lit's `render()`, so a returned HTML string was shown as
  escaped code. The formatter now returns an `HTMLElement` (valid for both the
  new Lit path and the older ECharts html-tooltip path).
- **Room edit dialogs** — `rs-edit-dialog` fired a composed `dialog-closed`
  event with a null detail. HA's reworked dialog manager listens for that
  reserved name and reads `e.detail.dialog`, throwing
  `TypeError: can't access property "dialog", e.detail is null` and breaking
  the edit dialogs. Renamed the internal event to `rs-dialog-closed`.
- **Comfort/Eco (and all text) inputs** — the `ha-textfield` polyfill was
  registered *after* the `ha-entity-picker` fast-path return in
  `load-ha-elements`. On 2026.6 `ha-entity-picker` is already defined at panel
  start, so the function returned early and the polyfill never registered,
  leaving every `<ha-textfield>` empty. Moved the registration ahead of the
  fast-path return.

## Why

RoomMind 1.7.3 is unusable on Home Assistant 2026.6 (#334): the climate
control mode can't be selected, room comfort/eco temperature fields are
missing, the analytics temperature tooltip shows raw markup, and opening a
room's edit dialog throws in HA core. All stem from frontend components
removed/changed in the 2026.x migration. Each fix is guarded so older HA
versions keep their native elements and behaviour.

Closes #334

## Checklist

- [ ] Backend tests pass (`pytest tests/ -v`)
- [x] Frontend builds without errors (`cd frontend && npm run build`)
- [x] New strings added to both `en.json` and `de.json` (if applicable)
- [x] Tested on mobile layout (if UI change)
