### PR TITLE
fix: compressor protection ignores TRVs in cool_only rooms

### DIFF
--- a/custom_components/roommind/coordinator.py
+++ b/custom_components/roommind/coordinator.py
@@ -758,7 +758,19 @@ class RoomMindCoordinator(DataUpdateCoordinator):
                     if self._compressor_manager.check_must_stay_active(eid):
                         compressor_forced_on.add(eid)
 
-            if compressor_forced_off and compressor_forced_off >= set(all_device_eids):
+            # In cooling mode only ACs can cool, so TRVs must not prevent the IDLE
+            # transition when all cooling-capable devices are blocked.  In heating
+            # mode both TRVs and ACs can contribute, so the full device set applies.
+            _mode_relevant_eids = (
+                set(get_ac_eids(room.get("devices", [])))
+                if mode == MODE_COOLING
+                else set(all_device_eids)
+            )
+            if (
+                compressor_forced_off
+                and _mode_relevant_eids
+                and compressor_forced_off >= _mode_relevant_eids
+            ):
                 mode = MODE_IDLE
                 power_fraction = 0.0
                 compressor_forced_off.clear()

--- a/custom_components/roommind/coordinator.py
+++ b/custom_components/roommind/coordinator.py
@@ -762,15 +762,9 @@ class RoomMindCoordinator(DataUpdateCoordinator):
             # transition when all cooling-capable devices are blocked.  In heating
             # mode both TRVs and ACs can contribute, so the full device set applies.
             _mode_relevant_eids = (
-                set(get_ac_eids(room.get("devices", [])))
-                if mode == MODE_COOLING
-                else set(all_device_eids)
+                set(get_ac_eids(room.get("devices", []))) if mode == MODE_COOLING else set(all_device_eids)
             )
-            if (
-                compressor_forced_off
-                and _mode_relevant_eids
-                and compressor_forced_off >= _mode_relevant_eids
-            ):
+            if compressor_forced_off and _mode_relevant_eids and compressor_forced_off >= _mode_relevant_eids:
                 mode = MODE_IDLE
                 power_fraction = 0.0
                 compressor_forced_off.clear()

--- a/tests/coordinator/test_heat_source.py
+++ b/tests/coordinator/test_heat_source.py
@@ -457,3 +457,68 @@ class TestHeatSourceOrchestration:
         # Deactivate last member, compressor stops
         coordinator._compressor_manager.update_member("climate.ac_b", False)
         assert coordinator._compressor_manager.is_compressor_running("shared_outdoor") is False
+
+    @pytest.mark.asyncio
+    async def test_compressor_min_off_blocks_ac_in_cool_only_room_with_trv(
+        self, hass, mock_config_entry
+    ):
+        """Compressor protection sets mode to IDLE in a cool_only room that also has a TRV.
+
+        Regression test: before the fix, the TRV's presence in all_device_eids caused
+        the 'all grouped devices blocked' check to never trigger, leaving mode as
+        'cooling' even though the only cooling-capable device was protected.
+        """
+        mixed_room = {
+            **SAMPLE_ROOM,
+            "thermostats": ["climate.living_room_trv"],
+            "acs": ["climate.living_room_ac"],
+            "devices": [
+                {
+                    "entity_id": "climate.living_room_trv",
+                    "type": "trv",
+                    "role": "auto",
+                    "heating_system_type": "radiator",
+                },
+                {
+                    "entity_id": "climate.living_room_ac",
+                    "type": "ac",
+                    "role": "auto",
+                    "heating_system_type": "",
+                    "idle_action": "fan_only",
+                },
+            ],
+            "climate_mode": "cool_only",
+        }
+        store = _make_store_mock({"living_room_abc12345": mixed_room})
+        store.get_settings.return_value = {
+            "compressor_groups": [
+                {
+                    "id": "group1",
+                    "name": "Outdoor Unit",
+                    "members": ["climate.living_room_ac"],
+                    "min_run_minutes": 5,
+                    "min_off_minutes": 5,
+                }
+            ],
+        }
+        hass.data = {"roommind": {"store": store}}
+
+        # Room is warm so coordinator wants to cool (temp=28, comfort_cool=24)
+        hass.states.get = MagicMock(side_effect=make_mock_states_get(temp="28.0"))
+        hass.services.async_call = AsyncMock()
+
+        coordinator = _create_coordinator(hass, mock_config_entry)
+
+        # Simulate AC recently deactivated — min-off not yet expired
+        coordinator._compressor_manager.load_groups(store.get_settings()["compressor_groups"])
+        coordinator._compressor_manager.update_member("climate.living_room_ac", True)
+        coordinator._compressor_manager.update_member("climate.living_room_ac", False)
+
+        data = await coordinator._async_update_data()
+        room_state = data["rooms"]["living_room_abc12345"]
+
+        # The AC is the only cooling-capable device and it is blocked: mode must be IDLE.
+        # A TRV in the room must not prevent this transition (TRVs cannot cool).
+        assert room_state["mode"] == MODE_IDLE, (
+            "cool_only room with blocked AC should be IDLE even when a TRV is present"
+        )

--- a/tests/coordinator/test_heat_source.py
+++ b/tests/coordinator/test_heat_source.py
@@ -459,9 +459,7 @@ class TestHeatSourceOrchestration:
         assert coordinator._compressor_manager.is_compressor_running("shared_outdoor") is False
 
     @pytest.mark.asyncio
-    async def test_compressor_min_off_blocks_ac_in_cool_only_room_with_trv(
-        self, hass, mock_config_entry
-    ):
+    async def test_compressor_min_off_blocks_ac_in_cool_only_room_with_trv(self, hass, mock_config_entry):
         """Compressor protection sets mode to IDLE in a cool_only room that also has a TRV.
 
         Regression test: before the fix, the TRV's presence in all_device_eids caused


### PR DESCRIPTION
## Problem

In a `cool_only` room that contains **both a TRV and an AC**, compressor protection (min-off timer) never forces the room to `idle` — even when the only cooling-capable device is blocked.

**Root cause** (`coordinator.py`, compressor constraint check):

```python
# Before: compares against ALL devices, including the TRV
if compressor_forced_off and compressor_forced_off >= set(all_device_eids):
    mode = MODE_IDLE
```

`all_device_eids` includes the TRV. Because the TRV is never a member of a compressor group, it is never added to `compressor_forced_off`. The superset check therefore always fails, and `mode` stays `"cooling"` even though the only cooling-capable device is protected.

The MPC controller still calls `async_idle_device` on the AC individually (→ `fan_only` / `idle_action`), but the room mode sensor reports `"cooling"`, and the mode-to-IDLE path (residual tracker, EKF label, etc.) is never taken.

## Fix

When `mode == MODE_COOLING`, narrow the reference set to **AC devices only**. TRVs cannot cool and must not prevent the `IDLE` transition. The heating branch keeps the full device set, since both TRVs and ACs can contribute to heating.

```python
# After: only cooling-capable devices count in cooling mode
_mode_relevant_eids = (
    set(get_ac_eids(room.get("devices", [])))
    if mode == MODE_COOLING
    else set(all_device_eids)
)
if (
    compressor_forced_off
    and _mode_relevant_eids
    and compressor_forced_off >= _mode_relevant_eids
):
    mode = MODE_IDLE
    power_fraction = 0.0
    compressor_forced_off.clear()
```

## Test

Added `test_compressor_min_off_blocks_ac_in_cool_only_room_with_trv` to `tests/coordinator/test_heat_source.py`. It creates a `cool_only` room with one TRV and one AC (AC in a compressor group with unexpired min-off), verifies that `mode == "idle"` — which would have failed before this fix.

Full suite: **1922 passed**.

## Real-world scenario that triggered this

A Daikin Multi-Split system with a `cool_only` bedroom room containing a Sonoff TRV (for winter, currently inactive) and a Faikin/Daikin AC. During compressor protection the room mode sensor showed `"cooling"` while the AC was in `fan_only`, making it impossible to distinguish "actively cooling" from "waiting for protection to expire".