### PR TITLE
Add device target to analytics graph

### DIFF
--- a/frontend/src/components/analytics/rs-analytics-chart.ts
+++ b/frontend/src/components/analytics/rs-analytics-chart.ts
@@ -22,7 +22,7 @@ export class RsAnalyticsChart extends LitElement {
   @property({ type: String }) public language = "en";
   @property({ type: Boolean }) public isOutdoor = false;
 
-  @state() private _hiddenSeries = new Set(["outdoor_temp"]);
+  @state() private _hiddenSeries = new Set(["outdoor_temp", "device_target"]);
   @state() private _chartInfoExpanded = false;
 
   render() {

--- a/frontend/src/utils/chart-builder.ts
+++ b/frontend/src/utils/chart-builder.ts
@@ -29,6 +29,7 @@ export function buildChartSeries(
   const targetData: Array<[number, number]> = [];
   const predictedData: Array<[number, number]> = [];
   const outdoorData: Array<[number, number]> = [];
+  const deviceTargetData: Array<[number, number]> = [];
 
   for (const p of points) {
     const ts = p.ts * 1000;
@@ -36,6 +37,7 @@ export function buildChartSeries(
     if (!isOutdoor && p.target_temp !== null) targetData.push([ts, d(p.target_temp)]);
     if (!isOutdoor && p.predicted_temp !== null) predictedData.push([ts, d(p.predicted_temp)]);
     if (p.outdoor_temp !== null) outdoorData.push([ts, d(p.outdoor_temp)]);
+    if (!isOutdoor && p.device_setpoint != null) deviceTargetData.push([ts, d(p.device_setpoint)]);
   }
 
   for (const p of forecast ?? []) {
@@ -82,6 +84,21 @@ export function buildChartSeries(
       showSymbol: false,
       smooth: true,
       lineStyle: { width: 2, type: "dotted" },
+      yAxisIndex: 0,
+    });
+  }
+
+  if (deviceTargetData.length > 0) {
+    series.push({
+      id: "device_target",
+      type: "line",
+      name: "TRV / AC",
+      color: "rgb(156, 39, 176)",
+      data: deviceTargetData,
+      showSymbol: false,
+      smooth: false,
+      step: "end",
+      lineStyle: { width: 1, type: "dashed" },
       yAxisIndex: 0,
     });
   }


### PR DESCRIPTION
Introduce device target data to the analytics chart, defaulting to hidden

## Why

It's already visible on the tooltip, but can be helpful for debugging how the underlying entities are being controlled by Roommind over time.

## Checklist



- [x] Backend tests pass (`pytest tests/ -v`)
- [x] Frontend builds without errors (`cd frontend && npm run build`)
- [x] New strings added to `en.json`, `de.json` and `fr.json`. (if applicable)
- [x] Tested on mobile layout (if UI change)

